### PR TITLE
Fix thinking feature: strip gracefully instead of rejecting

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import time
 import logging
 from dotenv import load_dotenv
 
-from translation.forward import anthropic_to_openai
+from translation.forward import anthropic_to_openai, strip_thinking
 from translation.reverse import translate_response
 from translation.streaming import OpenAIToAnthropicStreamAdapter
 from translation.tools import set_tool_enrichment_hook
@@ -55,19 +55,29 @@ async def messages(request: Request):
     body = await request.json()
     start = time.time()
     try:
+        bridge_warnings = strip_thinking(body)
+        if bridge_warnings:
+            for w in bridge_warnings:
+                logger.info("Degraded feature: %s", w)
+
         openai_body = anthropic_to_openai(body)
         headers = {"Authorization": f"Bearer {XAI_API_KEY}", "Content-Type": "application/json"}
 
         if openai_body.get("stream"):
-            return await _stream(openai_body, headers)
+            return await _stream(openai_body, headers, bridge_warnings)
 
         resp = await client.post("/chat/completions", json=openai_body, headers=headers)
         data = resp.json()
         logger.info("xAI response in %.2fs (status=%d)", time.time() - start, resp.status_code)
         result = translate_response(data, status_code=resp.status_code)
+
         if resp.status_code != 200:
             return JSONResponse(status_code=resp.status_code, content=result)
-        return result
+
+        response_headers = {}
+        if bridge_warnings:
+            response_headers["X-Bridge-Warning"] = "; ".join(bridge_warnings)
+        return JSONResponse(content=result, headers=response_headers)
 
     except NotImplementedError as e:
         return JSONResponse(status_code=400, content={
@@ -81,7 +91,9 @@ async def messages(request: Request):
             "_links": {"retry": {"href": "/v1/messages", "method": "POST"}, "manifest": {"href": "/manifest"}}})
 
 
-async def _stream(openai_body: dict, headers: dict[str, str]) -> StreamingResponse:
+async def _stream(
+    openai_body: dict, headers: dict[str, str], bridge_warnings: list[str] | None = None,
+) -> StreamingResponse:
     async def gen():
         async with client.stream("POST", "/chat/completions", json=openai_body, headers=headers) as resp:
             async def lines():
@@ -91,7 +103,11 @@ async def _stream(openai_body: dict, headers: dict[str, str]) -> StreamingRespon
             adapter = OpenAIToAnthropicStreamAdapter(lines())
             async for event in adapter:
                 yield f"event: {event.get('type', 'unknown')}\ndata: {json.dumps(event)}\n\n"
-    return StreamingResponse(gen(), media_type="text/event-stream")
+
+    response_headers = {}
+    if bridge_warnings:
+        response_headers["X-Bridge-Warning"] = "; ".join(bridge_warnings)
+    return StreamingResponse(gen(), media_type="text/event-stream", headers=response_headers)
 
 
 if __name__ == "__main__":

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -76,19 +76,34 @@ class TestBridgeStartup:
 class TestErrorHandling:
     """Verify error responses follow Anthropic format."""
 
-    def test_unsupported_thinking_feature(self, client: TestClient) -> None:
-        resp = client.post("/v1/messages", json={
-            "model": "claude-sonnet-4-20250514",
-            "max_tokens": 1024,
-            "thinking": True,
-            "messages": [{"role": "user", "content": "Hello"}],
+    def test_thinking_feature_stripped_not_rejected(self, client: TestClient) -> None:
+        """Thinking param is gracefully stripped, not rejected with 400."""
+        mock_post, _ = _mock_xai_response({
+            "id": "chatcmpl-think1",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
         })
-        assert resp.status_code == 400
+
+        import main
+        with patch.object(main.client, "post", side_effect=mock_post):
+            resp = client.post("/v1/messages", json={
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 1024,
+                "thinking": {"type": "enabled", "budget_tokens": 10000},
+                "messages": [{"role": "user", "content": "Hello"}],
+            })
+
+        assert resp.status_code == 200
         data = resp.json()
-        assert data["type"] == "error"
-        assert data["error"]["type"] == "invalid_request_error"
-        assert "thinking" in data["error"]["message"]
-        assert "suggestion" in data["error"]
+        assert data["type"] == "message"
+        assert data["content"][0]["text"] == "Hello!"
+        assert "X-Bridge-Warning" in resp.headers
+        assert "thinking" in resp.headers["X-Bridge-Warning"].lower()
 
     def test_unsupported_image_content(self, client: TestClient) -> None:
         resp = client.post("/v1/messages", json={

--- a/tests/translation/test_thinking.py
+++ b/tests/translation/test_thinking.py
@@ -1,0 +1,338 @@
+"""Tests for thinking feature handling in the translation layer.
+
+Anthropic's 'thinking' parameter (extended thinking / chain-of-thought)
+is not supported by xAI's Chat Completions API. The bridge must:
+1. Strip the thinking parameter from requests (not reject them)
+2. Strip thinking/redacted_thinking content blocks from messages
+3. Forward the request normally to get a valid response
+4. Signal degradation via warnings (Agentic API Standard Pattern 3)
+
+Grok models reason internally -- stripping thinking does NOT reduce
+response quality; it simply removes a parameter xAI does not accept.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from translation.forward import anthropic_to_openai, strip_thinking, translate_messages
+
+
+class TestStripThinkingParameter:
+    """Stripping the top-level 'thinking' parameter from requests."""
+
+    def test_thinking_enabled_stripped(self) -> None:
+        """thinking: {type: enabled, budget_tokens: N} is removed."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 16000,
+            "thinking": {"type": "enabled", "budget_tokens": 10000},
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        assert "thinking" not in request
+        assert len(warnings) >= 1
+        assert any("thinking" in w.lower() for w in warnings)
+
+    def test_thinking_adaptive_stripped(self) -> None:
+        """thinking: {type: adaptive} (Opus 4.6) is removed."""
+        request: dict[str, Any] = {
+            "model": "claude-opus-4-20250514",
+            "max_tokens": 16000,
+            "thinking": {"type": "adaptive"},
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        assert "thinking" not in request
+        assert len(warnings) >= 1
+
+    def test_thinking_true_stripped(self) -> None:
+        """thinking: true (boolean shorthand) is removed."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "thinking": True,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        assert "thinking" not in request
+        assert len(warnings) >= 1
+
+    def test_no_thinking_no_warnings(self) -> None:
+        """Request without thinking produces no warnings."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        assert warnings == []
+
+    def test_thinking_false_no_warning(self) -> None:
+        """thinking: false is falsy -- no stripping needed."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "thinking": False,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        # False is falsy, so no stripping occurs
+        assert warnings == []
+
+    def test_thinking_none_no_warning(self) -> None:
+        """thinking: null/None is falsy -- no stripping needed."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "thinking": None,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        assert warnings == []
+
+
+class TestStripThinkingContentBlocks:
+    """Stripping thinking/redacted_thinking blocks from message history."""
+
+    def test_thinking_block_stripped_from_assistant_message(self) -> None:
+        """Thinking blocks in assistant messages are removed."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Let me calculate 2+2...",
+                            "signature": "abc123...",
+                        },
+                        {"type": "text", "text": "The answer is 4."},
+                    ],
+                },
+                {"role": "user", "content": "Thanks!"},
+            ],
+        }
+        warnings = strip_thinking(request)
+
+        assistant_content = request["messages"][1]["content"]
+        assert len(assistant_content) == 1
+        assert assistant_content[0]["type"] == "text"
+        assert assistant_content[0]["text"] == "The answer is 4."
+        assert any("thinking" in w.lower() for w in warnings)
+
+    def test_redacted_thinking_block_stripped(self) -> None:
+        """Redacted thinking blocks are also removed."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "redacted_thinking",
+                            "data": "encrypted_content_here...",
+                        },
+                        {"type": "text", "text": "Based on my analysis..."},
+                    ],
+                },
+            ],
+        }
+        warnings = strip_thinking(request)
+
+        assistant_content = request["messages"][0]["content"]
+        assert len(assistant_content) == 1
+        assert assistant_content[0]["type"] == "text"
+
+    def test_mixed_thinking_and_tool_use_preserved(self) -> None:
+        """Tool use blocks survive when thinking blocks are stripped."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "I need to read the file...",
+                            "signature": "sig...",
+                        },
+                        {"type": "text", "text": "Let me check."},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_123",
+                            "name": "Read",
+                            "input": {"file_path": "/tmp/test.py"},
+                        },
+                    ],
+                },
+            ],
+        }
+        strip_thinking(request)
+
+        content = request["messages"][0]["content"]
+        types = [b["type"] for b in content]
+        assert "thinking" not in types
+        assert "text" in types
+        assert "tool_use" in types
+        assert len(content) == 2
+
+    def test_string_content_not_affected(self) -> None:
+        """Messages with string content (not block arrays) are untouched."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "Hello"},
+            ],
+        }
+        warnings = strip_thinking(request)
+
+        assert request["messages"][0]["content"] == "Hello"
+        assert warnings == []
+
+    def test_all_blocks_thinking_leaves_empty_content(self) -> None:
+        """If all blocks are thinking, content becomes empty list."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Reasoning...",
+                            "signature": "sig...",
+                        },
+                    ],
+                },
+            ],
+        }
+        strip_thinking(request)
+
+        assert request["messages"][0]["content"] == []
+
+
+class TestThinkingEndToEnd:
+    """Full translation with thinking -- strip then translate."""
+
+    def test_request_with_thinking_translates_successfully(self) -> None:
+        """A request with thinking param translates to valid OpenAI format."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 16000,
+            "thinking": {"type": "enabled", "budget_tokens": 10000},
+            "messages": [{"role": "user", "content": "Solve this math problem."}],
+        }
+        strip_thinking(request)
+        result = anthropic_to_openai(request)
+
+        assert "messages" in result
+        assert result["messages"][-1]["content"] == "Solve this math problem."
+        assert "thinking" not in result
+
+    def test_conversation_with_thinking_history_translates(self) -> None:
+        """Multi-turn conversation with thinking blocks in history translates."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 16000,
+            "thinking": {"type": "enabled", "budget_tokens": 10000},
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Simple arithmetic: 2+2=4",
+                            "signature": "sig123",
+                        },
+                        {"type": "text", "text": "4"},
+                    ],
+                },
+                {"role": "user", "content": "And 3+3?"},
+            ],
+        }
+        strip_thinking(request)
+        result = anthropic_to_openai(request)
+
+        # Verify the conversation translates without thinking artifacts
+        messages = result["messages"]
+        for msg in messages:
+            content = msg.get("content", "")
+            assert "thinking" not in str(content).lower() or "thinking" not in msg.get("role", "")
+
+    def test_thinking_blocks_in_messages_do_not_reach_translate(self) -> None:
+        """After strip_thinking, translate_messages sees no thinking blocks."""
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "...", "signature": "..."},
+                    {"type": "text", "text": "Hi there!"},
+                ],
+            },
+        ]
+        # Simulate strip_thinking on the messages
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, list):
+                msg["content"] = [
+                    b for b in content if b.get("type") not in ("thinking", "redacted_thinking")
+                ]
+
+        result = translate_messages(messages)
+
+        # No crash, valid output
+        assert len(result) == 2
+        assert result[0]["content"] == "Hello"
+        assert result[1]["content"] == "Hi there!"
+
+
+class TestWarningFormat:
+    """Warning messages follow Agentic API Standard Pattern 3."""
+
+    def test_warning_mentions_grok_reasoning(self) -> None:
+        """Warning explains that Grok reasons internally."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "thinking": {"type": "enabled", "budget_tokens": 5000},
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        warnings = strip_thinking(request)
+
+        assert len(warnings) >= 1
+        warning_text = " ".join(warnings).lower()
+        assert "grok" in warning_text
+        assert "reason" in warning_text or "stripped" in warning_text
+
+    def test_warning_is_not_an_error(self) -> None:
+        """Stripping thinking should NOT raise any exception."""
+        request: dict[str, Any] = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "thinking": {"type": "enabled", "budget_tokens": 50000},
+            "messages": [{"role": "user", "content": "Complex reasoning task"}],
+        }
+        # Must not raise
+        warnings = strip_thinking(request)
+        result = anthropic_to_openai(request)
+
+        assert isinstance(result, dict)
+        assert isinstance(warnings, list)

--- a/translation/__init__.py
+++ b/translation/__init__.py
@@ -5,7 +5,7 @@ Converts Claude Code (Anthropic Messages API) traffic into xAI/Grok
 enrichment injection hooks at every boundary.
 """
 
-from translation.forward import anthropic_to_openai, translate_messages, translate_tools
+from translation.forward import anthropic_to_openai, translate_messages, translate_tools, strip_thinking
 from translation.reverse import openai_to_anthropic, translate_response
 from translation.streaming import translate_sse_event, OpenAIToAnthropicStreamAdapter
 from translation.config import TranslationConfig
@@ -14,6 +14,7 @@ __all__ = [
     "anthropic_to_openai",
     "translate_messages",
     "translate_tools",
+    "strip_thinking",
     "openai_to_anthropic",
     "translate_response",
     "translate_sse_event",

--- a/translation/config.py
+++ b/translation/config.py
@@ -38,7 +38,10 @@ DEGRADED_FEATURES: frozenset[str] = frozenset({
 })
 
 # Features that fail loudly (raise NotImplementedError)
-UNSUPPORTED_FEATURES: frozenset[str] = frozenset({
+UNSUPPORTED_FEATURES: frozenset[str] = frozenset()
+
+# Features stripped from requests (Grok handles reasoning internally)
+STRIPPED_FEATURES: frozenset[str] = frozenset({
     "thinking",
 })
 

--- a/translation/forward.py
+++ b/translation/forward.py
@@ -9,13 +9,60 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from translation.config import TranslationConfig, UNSUPPORTED_FEATURES
+import logging
+
+from translation.config import TranslationConfig, UNSUPPORTED_FEATURES, STRIPPED_FEATURES
 from translation.tools import translate_tools as _translate_tools
 
 # Re-export so tests can import from translation.forward
 translate_tools = _translate_tools
 
 _config = TranslationConfig()
+logger = logging.getLogger(__name__)
+
+# Content block types that belong to Anthropic's thinking feature.
+# These are stripped from messages when forwarding to xAI.
+_THINKING_BLOCK_TYPES: frozenset[str] = frozenset({
+    "thinking",
+    "redacted_thinking",
+})
+
+
+def strip_thinking(request: dict[str, Any]) -> list[str]:
+    """Strip thinking-related fields from an Anthropic request.
+
+    Removes the top-level 'thinking' parameter and any thinking/redacted_thinking
+    content blocks from messages. Grok models reason internally and do not need
+    (or support) explicit thinking parameters.
+
+    Returns a list of warning strings for stripped features.
+    """
+    warnings: list[str] = []
+
+    for feature in STRIPPED_FEATURES:
+        if feature in request and request[feature]:
+            warnings.append(
+                f"'{feature}' parameter stripped. "
+                f"Grok models reason internally; response quality is not affected."
+            )
+            del request[feature]
+
+    # Strip thinking content blocks from conversation history
+    for msg in request.get("messages", []):
+        content = msg.get("content")
+        if isinstance(content, list):
+            filtered = [
+                block for block in content
+                if block.get("type") not in _THINKING_BLOCK_TYPES
+            ]
+            if len(filtered) < len(content):
+                msg["content"] = filtered
+                if not any("thinking" in w for w in warnings):
+                    warnings.append(
+                        "Thinking content blocks stripped from conversation history."
+                    )
+
+    return warnings
 
 
 def anthropic_to_openai(request: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- **URGENT**: Dan hit `'Feature thinking is not supported by the xAI bridge'` error during live testing
- The bridge was rejecting requests with Anthropic's `thinking` parameter (extended thinking / chain-of-thought) with a 400 error
- Grok models reason internally -- the `thinking` parameter should be silently stripped, not rejected
- Requests with thinking now succeed normally with a degraded response signal via `X-Bridge-Warning` header

## Changes

- Move `thinking` from `UNSUPPORTED_FEATURES` (hard reject) to `STRIPPED_FEATURES` (graceful strip) in `config.py`
- Add `strip_thinking()` in `forward.py`: removes the thinking parameter AND thinking/redacted_thinking content blocks from conversation history
- Return `X-Bridge-Warning` header when features are stripped (Agentic API Standard Pattern 3)
- Propagate warnings through both non-streaming and streaming response paths
- 16 new tests in `tests/translation/test_thinking.py`
- Update E2E test to verify 200 (not 400) for thinking requests

## Research

- xAI does NOT have an equivalent `thinking` parameter. Their reasoning models (`grok-4`, `grok-4-fast-reasoning`) reason internally by default.
- `grok-3-mini` supports `reasoning_effort` (low/high) but only on the Responses API, not Chat Completions
- Anthropic's thinking param comes as `{"type": "enabled", "budget_tokens": N}` or `{"type": "adaptive"}`
- Claude Code also sends thinking/redacted_thinking content blocks in conversation history that must be filtered

## Test plan

- [x] All 288 tests pass (272 existing + 16 new)
- [x] Parameter stripping: enabled, adaptive, boolean true all stripped
- [x] Falsy values (false, null) not flagged
- [x] Content block filtering: thinking, redacted_thinking blocks removed
- [x] Tool use blocks preserved when mixed with thinking blocks
- [x] End-to-end: request with thinking translates to valid OpenAI format
- [x] Warning header present in response
- [x] E2E: `/v1/messages` with thinking returns 200, not 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)