### PR TITLE
Add Grok identity preamble and strip Anthropic identity claims

### DIFF
--- a/enrichment/system_preamble.md
+++ b/enrichment/system_preamble.md
@@ -1,10 +1,12 @@
 # System Prompt Preamble
 
-Behavioral conventions injected into the system prompt for every request through the xAI bridge. This is the GLOBAL context that teaches Grok how to operate as a Claude Code agent.
+Identity assertion and behavioral conventions injected into the system prompt for every request through the xAI bridge. This is the GLOBAL context that (1) establishes Grok's identity and (2) teaches Grok how to operate as a Claude Code agent.
 
 ## Purpose
 
-Claude Code agents learn tool usage patterns, sequencing rules, and safety conventions through Anthropic's RL training. Grok has no equivalent training. This preamble transfers that behavioral knowledge at the system prompt level, complementing the per-tool enrichment from the enrichment engine.
+Claude Code sends system prompts that claim the model is "Claude Opus" or "powered by Anthropic." When Grok receives these claims, it role-plays as Claude instead of being itself. The identity preamble overrides these claims, and `strip_anthropic_identity()` removes them from the system text.
+
+Claude Code agents also learn tool usage patterns, sequencing rules, and safety conventions through Anthropic's RL training. Grok has no equivalent training. The behavioral preamble transfers that knowledge at the system prompt level.
 
 ## Architecture
 
@@ -12,14 +14,40 @@ Claude Code agents learn tool usage patterns, sequencing rules, and safety conve
 Request Flow:
   Claude Code -> Anthropic Messages API
     -> forward.py: anthropic_to_openai()
-      -> system_preamble prepended to system message
+      -> strip_anthropic_identity() removes Claude identity claims
+      -> system_preamble prepended (identity + behavioral)
       -> tools enriched via tool_enrichment_hook
     -> xAI Chat Completions API (Grok)
 ```
 
-The preamble is injected in `translation/forward.py` via `TranslationConfig.system_prompt_preamble`. The `get_system_preamble()` function respects the `PREAMBLE_ENABLED` environment variable for A/B benchmarking.
+The preamble is injected in `translation/forward.py` via `TranslationConfig.system_prompt_preamble`. Identity stripping happens in `forward.py`'s `anthropic_to_openai()` via `strip_anthropic_identity()`. Both respect their respective environment variables.
 
-## Six Behavioral Areas
+## Identity Section
+
+The identity preamble is prepended BEFORE behavioral conventions and BEFORE the user's system prompt. It establishes:
+
+1. "You are Grok (xAI)" -- truthful identity assertion
+2. "Disregard Claude/Anthropic identity claims" -- override stale context
+3. "Follow tool conventions as environment rules" -- behavioral compliance without identity confusion
+4. "Respond truthfully about your model" -- when asked directly
+
+## Anthropic Identity Stripping
+
+`strip_anthropic_identity()` removes known Claude Code identity patterns from the system text:
+
+- "You are powered by the model named Claude Opus 4.6..."
+- "The exact model ID is claude-opus-4-6."
+- "Assistant knowledge cutoff is..."
+- `<claude_background_info>` blocks
+- `<fast_mode_info>` blocks
+
+This is a surgical regex-based approach targeting known patterns, not a broad content filter.
+
+## Seven Preamble Areas
+
+### 0. Identity (NEW)
+
+Grok identity assertion, Claude identity override, environment convention framing.
 
 ### 1. Tool Preference Hierarchy
 
@@ -52,18 +80,27 @@ Tool results as source of truth, concise responses, file paths with line numbers
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PREAMBLE_ENABLED` | `true` | Set to `false` to disable preamble injection (benchmark mode) |
+| `PREAMBLE_ENABLED` | `true` | Set to `false` to disable behavioral conventions (benchmark mode) |
+| `IDENTITY_ENABLED` | `true` | Set to `false` to disable identity assertion and identity stripping |
 
 ## API
 
 ```python
-from enrichment.system_preamble import get_system_preamble, inject_system_preamble
+from enrichment.system_preamble import (
+    get_system_preamble,
+    inject_system_preamble,
+    strip_anthropic_identity,
+)
 
-# Get the preamble (respects PREAMBLE_ENABLED env var)
+# Get the preamble (respects PREAMBLE_ENABLED and IDENTITY_ENABLED env vars)
 preamble = get_system_preamble()
+
+# Strip Anthropic identity claims from system text
+cleaned = strip_anthropic_identity("You are powered by Claude Opus 4.6. Be helpful.")
+# Result: "Be helpful."
 
 # Inject into OpenAI-format messages
 messages = [{"role": "system", "content": "You are helpful."}]
 enriched = inject_system_preamble(messages, preamble)
-# Result: system message content = preamble + "\n\n" + "You are helpful."
+# Result: system message content = identity + behavioral preamble + "\n\n" + "You are helpful."
 ```

--- a/enrichment/system_preamble.py
+++ b/enrichment/system_preamble.py
@@ -1,17 +1,70 @@
 """System prompt preamble for Claude Code behavioral conventions.
 
 Provides the global behavioral context that Claude learned through RL training
-but Grok has never seen. This covers tool preference hierarchy, sequencing
-rules, chaining patterns, parallelism, safety, and output conventions.
+but Grok has never seen. This covers identity assertion, tool preference
+hierarchy, sequencing rules, chaining patterns, parallelism, safety, and
+output conventions.
 
 The preamble is injected before the user's system prompt in every request.
 It can be disabled via PREAMBLE_ENABLED=false for benchmarking.
+Identity assertion can be disabled separately via IDENTITY_ENABLED=false.
 """
 
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
+
+_IDENTITY_PREAMBLE = """\
+# Identity
+
+You are Grok (xAI), running inside the Claude Code environment via the xAI bridge. \
+The system prompt below comes from Claude Code and will refer to Claude, Anthropic, \
+and specific Anthropic model names. Disregard those identity claims -- you are Grok.
+
+Follow all Claude Code tool conventions, output formats, and safety guidelines \
+exactly as described. These are environment conventions, not identity claims.
+
+When asked what model you are, respond truthfully: you are Grok by xAI, \
+operating through the Claude Code interface.
+"""
+
+# Patterns that assert Anthropic/Claude model identity in system prompts.
+# These are stripped from the system text before forwarding to Grok.
+_ANTHROPIC_IDENTITY_PATTERNS: list[re.Pattern[str]] = [
+    # "You are powered by the model named Claude Opus 4.6..."
+    re.compile(
+        r"You are powered by the model named[^\n.]*\.\s*"
+        r"(?:The exact model ID is[^\n.]*\.\s*)?",
+        re.IGNORECASE,
+    ),
+    # "You are powered by Claude Opus 4.6" (shorter variant)
+    re.compile(
+        r"You are powered by Claude[^\n.]*\.\s*",
+        re.IGNORECASE,
+    ),
+    # Standalone model ID references like "The exact model ID is claude-opus-4-6."
+    re.compile(
+        r"The exact model ID is claude[^\n.]*\.\s*",
+        re.IGNORECASE,
+    ),
+    # "Assistant knowledge cutoff is ..." (Anthropic-specific framing)
+    re.compile(
+        r"Assistant knowledge cutoff is[^\n.]*\.\s*",
+        re.IGNORECASE,
+    ),
+    # <claude_background_info> blocks
+    re.compile(
+        r"<claude_background_info>\s*.*?\s*</claude_background_info>\s*",
+        re.DOTALL | re.IGNORECASE,
+    ),
+    # <fast_mode_info> blocks referencing Claude
+    re.compile(
+        r"<fast_mode_info>\s*.*?\s*</fast_mode_info>\s*",
+        re.DOTALL | re.IGNORECASE,
+    ),
+]
 
 _PREAMBLE = """\
 # Claude Code Agent Conventions
@@ -85,12 +138,42 @@ or command output
 def get_system_preamble() -> str:
     """Return the full system prompt preamble text.
 
-    Returns an empty string if PREAMBLE_ENABLED is set to 'false'.
+    Identity section is prepended when IDENTITY_ENABLED is true (default).
+    Behavioral conventions follow when PREAMBLE_ENABLED is true (default).
+    Returns an empty string only when both are disabled.
     """
-    enabled = os.getenv("PREAMBLE_ENABLED", "true").lower()
-    if enabled == "false":
-        return ""
-    return _PREAMBLE
+    parts: list[str] = []
+
+    identity_enabled = os.getenv("IDENTITY_ENABLED", "true").lower()
+    if identity_enabled != "false":
+        parts.append(_IDENTITY_PREAMBLE)
+
+    preamble_enabled = os.getenv("PREAMBLE_ENABLED", "true").lower()
+    if preamble_enabled != "false":
+        parts.append(_PREAMBLE)
+
+    return "\n".join(parts)
+
+
+def strip_anthropic_identity(system_text: str) -> str:
+    """Remove Anthropic/Claude identity assertions from a system prompt.
+
+    Strips patterns like "You are powered by Claude Opus 4.6",
+    model ID references, and <claude_background_info> blocks.
+    Returns the cleaned text. If IDENTITY_ENABLED is false, returns
+    the text unchanged (no stripping needed when identity is not overridden).
+    """
+    identity_enabled = os.getenv("IDENTITY_ENABLED", "true").lower()
+    if identity_enabled == "false":
+        return system_text
+
+    result = system_text
+    for pattern in _ANTHROPIC_IDENTITY_PATTERNS:
+        result = pattern.sub("", result)
+
+    # Clean up leftover blank lines from stripped blocks
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result.strip()
 
 
 def inject_system_preamble(

--- a/tests/enrichment/test_system_preamble.py
+++ b/tests/enrichment/test_system_preamble.py
@@ -1,6 +1,7 @@
 """Tests for enrichment.system_preamble module.
 
-Covers: preamble content, env-based toggle, injection into message lists,
+Covers: identity preamble, behavioral preamble, env-based toggles,
+Anthropic identity stripping, injection into message lists,
 and integration with TranslationConfig.
 """
 
@@ -14,41 +15,102 @@ import pytest
 from enrichment.system_preamble import (
     get_system_preamble,
     inject_system_preamble,
+    strip_anthropic_identity,
     _PREAMBLE,
+    _IDENTITY_PREAMBLE,
 )
+
+
+class TestIdentityPreambleContent:
+    """Tests for identity preamble content."""
+
+    def test_identity_declares_grok(self) -> None:
+        """Identity preamble asserts Grok identity."""
+        assert "You are Grok" in _IDENTITY_PREAMBLE
+        assert "xAI" in _IDENTITY_PREAMBLE
+
+    def test_identity_disclaims_claude(self) -> None:
+        """Identity preamble tells model to disregard Claude claims."""
+        assert "Disregard" in _IDENTITY_PREAMBLE
+        assert "identity claims" in _IDENTITY_PREAMBLE
+
+    def test_identity_preserves_tool_conventions(self) -> None:
+        """Identity preamble frames tool conventions as environment rules."""
+        assert "environment conventions" in _IDENTITY_PREAMBLE
+
+    def test_identity_truthful_response(self) -> None:
+        """Identity preamble directs truthful model identification."""
+        assert "respond truthfully" in _IDENTITY_PREAMBLE
+        assert "Grok by xAI" in _IDENTITY_PREAMBLE
 
 
 class TestGetSystemPreamble:
     """Tests for get_system_preamble()."""
 
-    def test_returns_preamble_by_default(self) -> None:
-        """Preamble is returned when PREAMBLE_ENABLED is not set."""
+    def test_returns_identity_and_behavioral_by_default(self) -> None:
+        """Both identity and behavioral preamble returned by default."""
         with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PREAMBLE_ENABLED", None)
+            os.environ.pop("IDENTITY_ENABLED", None)
+            result = get_system_preamble()
+        assert _IDENTITY_PREAMBLE in result
+        assert _PREAMBLE in result
+        assert result.index(_IDENTITY_PREAMBLE) < result.index(_PREAMBLE)
+
+    def test_identity_before_behavioral(self) -> None:
+        """Identity section appears before behavioral conventions."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PREAMBLE_ENABLED", None)
+            os.environ.pop("IDENTITY_ENABLED", None)
+            result = get_system_preamble()
+        assert result.startswith("# Identity")
+
+    def test_preamble_disabled_returns_identity_only(self) -> None:
+        """When PREAMBLE_ENABLED=false, only identity is returned."""
+        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "false"}, clear=False):
+            os.environ.pop("IDENTITY_ENABLED", None)
+            result = get_system_preamble()
+        assert "You are Grok" in result
+        assert "Tool Preference Hierarchy" not in result
+
+    def test_identity_disabled_returns_behavioral_only(self) -> None:
+        """When IDENTITY_ENABLED=false, only behavioral conventions returned."""
+        with patch.dict(os.environ, {"IDENTITY_ENABLED": "false"}, clear=False):
             os.environ.pop("PREAMBLE_ENABLED", None)
             result = get_system_preamble()
         assert result == _PREAMBLE
-        assert len(result) > 0
+        assert "You are Grok" not in result
 
-    def test_returns_preamble_when_enabled_true(self) -> None:
-        """Preamble is returned when PREAMBLE_ENABLED=true."""
-        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "true"}):
-            result = get_system_preamble()
-        assert result == _PREAMBLE
-
-    def test_returns_empty_when_disabled(self) -> None:
-        """Empty string when PREAMBLE_ENABLED=false."""
-        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "false"}):
+    def test_both_disabled_returns_empty(self) -> None:
+        """Empty string when both PREAMBLE_ENABLED and IDENTITY_ENABLED are false."""
+        with patch.dict(os.environ, {
+            "PREAMBLE_ENABLED": "false",
+            "IDENTITY_ENABLED": "false",
+        }):
             result = get_system_preamble()
         assert result == ""
 
+    def test_both_enabled_explicitly(self) -> None:
+        """Explicit true for both returns full preamble."""
+        with patch.dict(os.environ, {
+            "PREAMBLE_ENABLED": "true",
+            "IDENTITY_ENABLED": "true",
+        }):
+            result = get_system_preamble()
+        assert "You are Grok" in result
+        assert "Tool Preference Hierarchy" in result
+
     def test_case_insensitive_false(self) -> None:
         """PREAMBLE_ENABLED=False (capital F) also disables."""
-        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "False"}):
+        with patch.dict(os.environ, {
+            "PREAMBLE_ENABLED": "False",
+            "IDENTITY_ENABLED": "False",
+        }):
             result = get_system_preamble()
         assert result == ""
 
     def test_preamble_contains_tool_hierarchy(self) -> None:
-        """Preamble covers tool preference hierarchy."""
+        """Behavioral preamble covers tool preference hierarchy."""
         assert "Tool Preference Hierarchy" in _PREAMBLE
         assert "Read" in _PREAMBLE
         assert "Grep" in _PREAMBLE
@@ -56,32 +118,168 @@ class TestGetSystemPreamble:
         assert "Edit" in _PREAMBLE
 
     def test_preamble_contains_sequencing_rules(self) -> None:
-        """Preamble covers sequencing rules."""
+        """Behavioral preamble covers sequencing rules."""
         assert "Sequencing Rules" in _PREAMBLE
         assert "Read a file BEFORE editing" in _PREAMBLE
 
     def test_preamble_contains_chaining_patterns(self) -> None:
-        """Preamble covers tool chaining patterns."""
+        """Behavioral preamble covers tool chaining patterns."""
         assert "Tool Chaining Patterns" in _PREAMBLE
         assert "Discovery" in _PREAMBLE
         assert "Modification" in _PREAMBLE
 
     def test_preamble_contains_parallel_rules(self) -> None:
-        """Preamble covers parallel vs sequential execution."""
+        """Behavioral preamble covers parallel vs sequential execution."""
         assert "Parallel vs Sequential" in _PREAMBLE
         assert "INDEPENDENT" in _PREAMBLE
         assert "DEPENDENT" in _PREAMBLE
 
     def test_preamble_contains_safety_patterns(self) -> None:
-        """Preamble covers safety patterns."""
+        """Behavioral preamble covers safety patterns."""
         assert "Safety Patterns" in _PREAMBLE
         assert "force push" in _PREAMBLE
         assert "credentials" in _PREAMBLE
 
     def test_preamble_contains_output_conventions(self) -> None:
-        """Preamble covers output conventions."""
+        """Behavioral preamble covers output conventions."""
         assert "Output Conventions" in _PREAMBLE
         assert "source of truth" in _PREAMBLE
+
+
+class TestStripAnthropicIdentity:
+    """Tests for strip_anthropic_identity()."""
+
+    def test_strips_powered_by_model_named(self) -> None:
+        """Strips 'You are powered by the model named ...' pattern."""
+        text = (
+            "Some context. "
+            "You are powered by the model named Opus 4.6. "
+            "The exact model ID is claude-opus-4-6. "
+            "More context."
+        )
+        result = strip_anthropic_identity(text)
+        assert "powered by the model named" not in result
+        assert "model ID" not in result
+        assert "Some context." in result
+        assert "More context." in result
+
+    def test_strips_powered_by_claude(self) -> None:
+        """Strips 'You are powered by Claude Opus 4.6' pattern."""
+        text = "Start. You are powered by Claude Opus 4.6. End."
+        result = strip_anthropic_identity(text)
+        assert "powered by Claude" not in result
+        assert "Start." in result
+        assert "End." in result
+
+    def test_strips_standalone_model_id(self) -> None:
+        """Strips standalone 'The exact model ID is claude-...' pattern."""
+        text = "Before. The exact model ID is claude-opus-4-6. After."
+        result = strip_anthropic_identity(text)
+        assert "exact model ID" not in result
+        assert "Before." in result
+        assert "After." in result
+
+    def test_strips_knowledge_cutoff(self) -> None:
+        """Strips 'Assistant knowledge cutoff is ...' pattern."""
+        text = "Context. Assistant knowledge cutoff is May 2025. More."
+        result = strip_anthropic_identity(text)
+        assert "knowledge cutoff" not in result
+        assert "Context." in result
+        assert "More." in result
+
+    def test_strips_claude_background_info_block(self) -> None:
+        """Strips <claude_background_info> XML blocks."""
+        text = (
+            "Before.\n"
+            "<claude_background_info>\n"
+            "The most recent frontier Claude model is Claude Opus 4.6.\n"
+            "</claude_background_info>\n"
+            "After."
+        )
+        result = strip_anthropic_identity(text)
+        assert "claude_background_info" not in result
+        assert "frontier Claude model" not in result
+        assert "Before." in result
+        assert "After." in result
+
+    def test_strips_fast_mode_info_block(self) -> None:
+        """Strips <fast_mode_info> XML blocks."""
+        text = (
+            "Before.\n"
+            "<fast_mode_info>\n"
+            "Fast mode for Claude Code uses the same model.\n"
+            "</fast_mode_info>\n"
+            "After."
+        )
+        result = strip_anthropic_identity(text)
+        assert "fast_mode_info" not in result
+        assert "Before." in result
+        assert "After." in result
+
+    def test_strips_full_realistic_system_prompt(self) -> None:
+        """Strips multiple identity patterns from a realistic system prompt."""
+        text = (
+            "You are a helpful assistant.\n\n"
+            "You are powered by the model named Opus 4.6. "
+            "The exact model ID is claude-opus-4-6.\n\n"
+            "Assistant knowledge cutoff is May 2025.\n\n"
+            "<claude_background_info>\n"
+            "The most recent frontier Claude model is Claude Opus 4.6 "
+            "(model ID: 'claude-opus-4-6').\n"
+            "</claude_background_info>\n\n"
+            "<fast_mode_info>\n"
+            "Fast mode for Claude Code uses the same Claude Opus 4.6 model "
+            "with faster output. It does NOT switch to a different model.\n"
+            "</fast_mode_info>\n\n"
+            "Follow the user's instructions carefully."
+        )
+        result = strip_anthropic_identity(text)
+        assert "powered by" not in result
+        assert "claude-opus" not in result
+        assert "knowledge cutoff" not in result
+        assert "claude_background_info" not in result
+        assert "fast_mode_info" not in result
+        assert "You are a helpful assistant." in result
+        assert "Follow the user's instructions carefully." in result
+
+    def test_preserves_non_identity_claude_references(self) -> None:
+        """Does not strip references to Claude that are not identity claims."""
+        text = "Use the Claude Code tool conventions described above."
+        result = strip_anthropic_identity(text)
+        assert "Claude Code tool conventions" in result
+
+    def test_no_excessive_blank_lines(self) -> None:
+        """Stripped content does not leave triple+ blank lines."""
+        text = (
+            "Start.\n\n"
+            "You are powered by Claude Opus 4.6.\n\n\n"
+            "End."
+        )
+        result = strip_anthropic_identity(text)
+        assert "\n\n\n" not in result
+
+    def test_empty_string_returns_empty(self) -> None:
+        """Empty input returns empty output."""
+        assert strip_anthropic_identity("") == ""
+
+    def test_no_match_returns_unchanged(self) -> None:
+        """Text with no identity patterns passes through unchanged."""
+        text = "Just a normal system prompt with instructions."
+        result = strip_anthropic_identity(text)
+        assert result == text
+
+    def test_disabled_returns_unchanged(self) -> None:
+        """When IDENTITY_ENABLED=false, stripping is skipped."""
+        text = "You are powered by Claude Opus 4.6. Be helpful."
+        with patch.dict(os.environ, {"IDENTITY_ENABLED": "false"}):
+            result = strip_anthropic_identity(text)
+        assert result == text
+
+    def test_case_insensitive(self) -> None:
+        """Identity stripping is case-insensitive."""
+        text = "you are powered by claude opus 4.6. End."
+        result = strip_anthropic_identity(text)
+        assert "powered by claude" not in result
 
 
 class TestInjectSystemPreamble:
@@ -166,16 +364,26 @@ class TestIntegrationWithConfig:
         assert len(config.system_prompt_preamble) > 0
         assert "Tool Preference Hierarchy" in config.system_prompt_preamble
 
-    def test_config_empty_when_disabled(self) -> None:
-        """Config preamble is empty when PREAMBLE_ENABLED=false."""
-        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "false"}):
+    def test_config_includes_identity_by_default(self) -> None:
+        """TranslationConfig.system_prompt_preamble includes identity."""
+        from translation.config import TranslationConfig
+
+        config = TranslationConfig()
+        assert "You are Grok" in config.system_prompt_preamble
+
+    def test_config_empty_when_both_disabled(self) -> None:
+        """Config preamble is empty when both are disabled."""
+        with patch.dict(os.environ, {
+            "PREAMBLE_ENABLED": "false",
+            "IDENTITY_ENABLED": "false",
+        }):
             from translation.config import TranslationConfig
 
             config = TranslationConfig()
         assert config.system_prompt_preamble == ""
 
-    def test_forward_translation_includes_preamble(self) -> None:
-        """anthropic_to_openai() includes preamble in system message."""
+    def test_forward_translation_includes_identity_and_preamble(self) -> None:
+        """anthropic_to_openai() includes identity and preamble in system message."""
         from translation.forward import anthropic_to_openai
 
         request = {
@@ -189,5 +397,29 @@ class TestIntegrationWithConfig:
         result = anthropic_to_openai(request)
         system_msg = result["messages"][0]
         assert system_msg["role"] == "system"
+        assert "You are Grok" in system_msg["content"]
         assert "Tool Preference Hierarchy" in system_msg["content"]
         assert "You are a coding assistant." in system_msg["content"]
+
+    def test_forward_translation_strips_claude_identity(self) -> None:
+        """anthropic_to_openai() strips Claude identity claims from system text."""
+        from translation.forward import anthropic_to_openai
+
+        request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "system": (
+                "You are a coding assistant. "
+                "You are powered by the model named Opus 4.6. "
+                "The exact model ID is claude-opus-4-6."
+            ),
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ],
+        }
+        result = anthropic_to_openai(request)
+        system_msg = result["messages"][0]
+        assert "powered by the model named" not in system_msg["content"]
+        assert "claude-opus-4-6" not in system_msg["content"]
+        assert "You are a coding assistant." in system_msg["content"]
+        assert "You are Grok" in system_msg["content"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -278,19 +278,38 @@ class TestEnrichmentModeToggle:
         assert "behavioral_why" in result[0]
         assert "behavioral_when" in result[0]
 
-    def test_preamble_disabled(self) -> None:
-        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "false"}):
+    def test_preamble_disabled_identity_disabled(self) -> None:
+        """Both disabled returns empty."""
+        with patch.dict(os.environ, {
+            "PREAMBLE_ENABLED": "false",
+            "IDENTITY_ENABLED": "false",
+        }):
             import importlib
             import enrichment.system_preamble
             importlib.reload(enrichment.system_preamble)
             from enrichment.system_preamble import get_system_preamble
             assert get_system_preamble() == ""
 
-    def test_preamble_enabled(self) -> None:
-        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "true"}):
+    def test_preamble_disabled_identity_enabled(self) -> None:
+        """Behavioral disabled but identity still returned."""
+        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "false"}, clear=False):
+            os.environ.pop("IDENTITY_ENABLED", None)
             import importlib
             import enrichment.system_preamble
             importlib.reload(enrichment.system_preamble)
             from enrichment.system_preamble import get_system_preamble
-            assert len(get_system_preamble()) > 0
-            assert "Tool Preference Hierarchy" in get_system_preamble()
+            result = get_system_preamble()
+            assert "You are Grok" in result
+            assert "Tool Preference Hierarchy" not in result
+
+    def test_preamble_enabled(self) -> None:
+        with patch.dict(os.environ, {"PREAMBLE_ENABLED": "true"}, clear=False):
+            os.environ.pop("IDENTITY_ENABLED", None)
+            import importlib
+            import enrichment.system_preamble
+            importlib.reload(enrichment.system_preamble)
+            from enrichment.system_preamble import get_system_preamble
+            result = get_system_preamble()
+            assert len(result) > 0
+            assert "Tool Preference Hierarchy" in result
+            assert "You are Grok" in result

--- a/translation/forward.py
+++ b/translation/forward.py
@@ -13,6 +13,7 @@ import logging
 
 from translation.config import TranslationConfig, UNSUPPORTED_FEATURES, STRIPPED_FEATURES
 from translation.tools import translate_tools as _translate_tools
+from enrichment.system_preamble import strip_anthropic_identity
 
 # Re-export so tests can import from translation.forward
 translate_tools = _translate_tools
@@ -77,7 +78,8 @@ def anthropic_to_openai(request: dict[str, Any]) -> dict[str, Any]:
     messages: list[dict[str, Any]] = []
 
     # System prompt: top-level field -> system role message
-    system = request.get("system", "")
+    # Strip Anthropic identity claims before prepending our preamble
+    system = strip_anthropic_identity(request.get("system", ""))
     preamble = _config.system_prompt_preamble
     if preamble and system:
         system = f"{preamble}\n\n{system}"


### PR DESCRIPTION
## Summary

- Grok was role-playing as Claude because Claude Code injects "You are powered by Claude Opus 4.6" into the system prompt
- Added **identity preamble** at the top of every system prompt: "You are Grok (xAI), running inside the Claude Code environment via the xAI bridge"
- Added **`strip_anthropic_identity()`** to surgically remove Claude identity patterns from the system text before forwarding
- Hybrid approach (Option A + B): identity is asserted AND contradictory claims are stripped
- Independent env vars: `IDENTITY_ENABLED` and `PREAMBLE_ENABLED` can be toggled separately for A/B testing

## Files Modified

| File | Change |
|------|--------|
| `enrichment/system_preamble.py` | Added `_IDENTITY_PREAMBLE`, `strip_anthropic_identity()`, updated `get_system_preamble()` |
| `enrichment/system_preamble.md` | Updated docs with identity section, stripping patterns, new env var |
| `translation/forward.py` | Wired `strip_anthropic_identity()` into `anthropic_to_openai()` |
| `tests/enrichment/test_system_preamble.py` | 43 tests (was 21): identity content, stripping, env toggles, integration |
| `tests/test_e2e.py` | Updated preamble toggle tests for dual-env-var behavior |

## Identity Patterns Stripped

- `You are powered by the model named Opus 4.6. The exact model ID is claude-opus-4-6.`
- `You are powered by Claude Opus 4.6.`
- `Assistant knowledge cutoff is May 2025.`
- `<claude_background_info>...</claude_background_info>` blocks
- `<fast_mode_info>...</fast_mode_info>` blocks

## Test plan

- [x] 311 tests passing (+23 new, 0 regressions)
- [x] Identity preamble content verified (declares Grok, disclaims Claude, frames conventions)
- [x] Stripping verified against realistic Claude Code system prompt
- [x] Env var toggles tested independently and together
- [x] Forward translation integration tested (strips + prepends)
- [x] E2E tests updated for dual-toggle behavior
- [ ] Live test with Dan's bridge deployment

Generated with [Claude Code](https://claude.com/claude-code)