### PR TITLE
Fix: strip_anthropic_identity() crash on list-type system field

### DIFF
--- a/enrichment/system_preamble.py
+++ b/enrichment/system_preamble.py
@@ -34,22 +34,26 @@ operating through the Claude Code interface.
 # These are stripped from the system text before forwarding to Grok.
 _ANTHROPIC_IDENTITY_PATTERNS: list[re.Pattern[str]] = [
     # "You are powered by the model named Claude Opus 4.6..."
+    # Uses [^\n]*? (lazy, allows dots) + sentence-end anchor to handle
+    # version numbers like "4.6" without stopping at the internal period.
     re.compile(
-        r"You are powered by the model named[^\n.]*\.\s*"
-        r"(?:The exact model ID is[^\n.]*\.\s*)?",
-        re.IGNORECASE,
+        r"You are powered by the model named[^\n]*?(?:\.\s+|\.\s*$)"
+        r"(?:The exact model ID is[^\n]*?(?:\.\s+|\.\s*$))?",
+        re.IGNORECASE | re.MULTILINE,
     ),
     # "You are powered by Claude Opus 4.6" (shorter variant)
     re.compile(
-        r"You are powered by Claude[^\n.]*\.\s*",
-        re.IGNORECASE,
+        r"You are powered by Claude[^\n]*?(?:\.\s+|\.\s*$)",
+        re.IGNORECASE | re.MULTILINE,
     ),
     # Standalone model ID references like "The exact model ID is claude-opus-4-6."
+    # Model IDs use hyphens not dots, so [^\n.] is safe here.
     re.compile(
         r"The exact model ID is claude[^\n.]*\.\s*",
         re.IGNORECASE,
     ),
     # "Assistant knowledge cutoff is ..." (Anthropic-specific framing)
+    # Month names don't contain dots, so [^\n.] is safe here.
     re.compile(
         r"Assistant knowledge cutoff is[^\n.]*\.\s*",
         re.IGNORECASE,
@@ -155,25 +159,56 @@ def get_system_preamble() -> str:
     return "\n".join(parts)
 
 
-def strip_anthropic_identity(system_text: str) -> str:
+def _strip_text(text: str) -> str:
+    """Apply identity-stripping regexes to a single string.
+
+    Returns the cleaned text with collapsed blank lines and stripped whitespace.
+    """
+    result = text
+    for pattern in _ANTHROPIC_IDENTITY_PATTERNS:
+        result = pattern.sub("", result)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result.strip()
+
+
+def strip_anthropic_identity(
+    system: str | list[dict[str, Any]],
+) -> str | list[dict[str, Any]]:
     """Remove Anthropic/Claude identity assertions from a system prompt.
 
+    Handles both system prompt formats sent by the Anthropic Messages API:
+    - String: applies regex patterns directly
+    - List of content blocks: iterates blocks, strips text in each
+      ``{"type": "text"}`` block, removes blocks that become empty
+
     Strips patterns like "You are powered by Claude Opus 4.6",
-    model ID references, and <claude_background_info> blocks.
-    Returns the cleaned text. If IDENTITY_ENABLED is false, returns
-    the text unchanged (no stripping needed when identity is not overridden).
+    model ID references, and ``<claude_background_info>`` blocks.
+    If IDENTITY_ENABLED is false, returns the input unchanged.
     """
     identity_enabled = os.getenv("IDENTITY_ENABLED", "true").lower()
     if identity_enabled == "false":
-        return system_text
+        return system
 
-    result = system_text
-    for pattern in _ANTHROPIC_IDENTITY_PATTERNS:
-        result = pattern.sub("", result)
+    if isinstance(system, str):
+        return _strip_text(system)
 
-    # Clean up leftover blank lines from stripped blocks
-    result = re.sub(r"\n{3,}", "\n\n", result)
-    return result.strip()
+    if isinstance(system, list):
+        result_blocks: list[dict[str, Any]] = []
+        for block in system:
+            if not isinstance(block, dict):
+                result_blocks.append(block)
+                continue
+            if block.get("type") != "text":
+                result_blocks.append(block)
+                continue
+            cleaned = _strip_text(block.get("text", ""))
+            if cleaned:
+                result_blocks.append({**block, "text": cleaned})
+        return result_blocks
+
+    raise TypeError(
+        f"Expected str or list for system field, got {type(system).__name__}"
+    )
 
 
 def inject_system_preamble(

--- a/tests/enrichment/test_system_preamble.py
+++ b/tests/enrichment/test_system_preamble.py
@@ -282,6 +282,151 @@ class TestStripAnthropicIdentity:
         assert "powered by claude" not in result
 
 
+class TestStripAnthropicIdentityListType:
+    """Tests for strip_anthropic_identity() with list-of-content-blocks system field.
+
+    The Anthropic Messages API sends the system field as either a string
+    or a list of typed content blocks. Claude Code uses the list format
+    for streaming/opus requests.
+    """
+
+    def test_list_type_returns_list(self) -> None:
+        """List input produces list output."""
+        system = [{"type": "text", "text": "Hello world."}]
+        result = strip_anthropic_identity(system)
+        assert isinstance(result, list)
+
+    def test_list_strips_identity_from_text_blocks(self) -> None:
+        """Identity patterns are stripped from text blocks in the list."""
+        system = [
+            {
+                "type": "text",
+                "text": (
+                    "You are a coding assistant. "
+                    "You are powered by Claude Opus 4.6. "
+                    "The exact model ID is claude-opus-4-6."
+                ),
+            }
+        ]
+        result = strip_anthropic_identity(system)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "powered by Claude" not in result[0]["text"]
+        assert "claude-opus-4-6" not in result[0]["text"]
+        assert "You are a coding assistant." in result[0]["text"]
+
+    def test_list_removes_empty_text_blocks(self) -> None:
+        """Text blocks that become empty after stripping are removed."""
+        system = [
+            {"type": "text", "text": "You are powered by Claude Opus 4.6."},
+            {"type": "text", "text": "Keep this block."},
+        ]
+        result = strip_anthropic_identity(system)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["text"] == "Keep this block."
+
+    def test_list_preserves_non_text_blocks(self) -> None:
+        """Non-text blocks (e.g., cache_control) are preserved unchanged."""
+        system = [
+            {"type": "text", "text": "You are powered by Claude Opus 4.6."},
+            {"type": "text", "text": "Instructions here.", "cache_control": {"type": "ephemeral"}},
+        ]
+        result = strip_anthropic_identity(system)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["text"] == "Instructions here."
+        assert result[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_list_strips_background_info_block(self) -> None:
+        """<claude_background_info> is stripped from text blocks in list."""
+        system = [
+            {
+                "type": "text",
+                "text": (
+                    "Before.\n"
+                    "<claude_background_info>\n"
+                    "Claude model info here.\n"
+                    "</claude_background_info>\n"
+                    "After."
+                ),
+            }
+        ]
+        result = strip_anthropic_identity(system)
+        assert "claude_background_info" not in result[0]["text"]
+        assert "Before." in result[0]["text"]
+        assert "After." in result[0]["text"]
+
+    def test_list_multiple_text_blocks_stripped_independently(self) -> None:
+        """Each text block is stripped independently."""
+        system = [
+            {"type": "text", "text": "Assistant knowledge cutoff is May 2025."},
+            {"type": "text", "text": "You are powered by Claude Opus 4.6."},
+            {"type": "text", "text": "Follow the user's instructions."},
+        ]
+        result = strip_anthropic_identity(system)
+        assert len(result) == 1
+        assert result[0]["text"] == "Follow the user's instructions."
+
+    def test_list_empty_list_returns_empty_list(self) -> None:
+        """Empty list input returns empty list."""
+        result = strip_anthropic_identity([])
+        assert result == []
+
+    def test_list_all_blocks_stripped_returns_empty_list(self) -> None:
+        """If all text blocks become empty, an empty list is returned."""
+        system = [
+            {"type": "text", "text": "You are powered by Claude Opus 4.6."},
+        ]
+        result = strip_anthropic_identity(system)
+        assert result == []
+
+    def test_list_disabled_returns_unchanged(self) -> None:
+        """When IDENTITY_ENABLED=false, list is returned unchanged."""
+        system = [
+            {"type": "text", "text": "You are powered by Claude Opus 4.6."},
+        ]
+        with patch.dict(os.environ, {"IDENTITY_ENABLED": "false"}):
+            result = strip_anthropic_identity(system)
+        assert result == system
+
+    def test_list_realistic_claude_code_system(self) -> None:
+        """Realistic Claude Code streaming system with multiple blocks."""
+        system = [
+            {
+                "type": "text",
+                "text": (
+                    "You are powered by the model named Claude Opus 4.6. "
+                    "The exact model ID is claude-opus-4-6.\n\n"
+                    "Assistant knowledge cutoff is May 2025.\n\n"
+                    "<claude_background_info>\n"
+                    "The most recent frontier Claude model is Claude Opus 4.6.\n"
+                    "</claude_background_info>\n\n"
+                    "<fast_mode_info>\n"
+                    "Fast mode uses the same Claude Opus 4.6 model.\n"
+                    "</fast_mode_info>"
+                ),
+            },
+            {
+                "type": "text",
+                "text": "You are an expert coding assistant. Follow all tool conventions.",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+        result = strip_anthropic_identity(system)
+        assert isinstance(result, list)
+        # First block should be stripped entirely (all identity patterns)
+        # Second block is preserved with cache_control
+        assert len(result) == 1
+        assert "expert coding assistant" in result[0]["text"]
+        assert result[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_invalid_type_raises_typeerror(self) -> None:
+        """Non-string, non-list input raises TypeError."""
+        with pytest.raises(TypeError, match="Expected str or list"):
+            strip_anthropic_identity(42)  # type: ignore[arg-type]
+
+
 class TestInjectSystemPreamble:
     """Tests for inject_system_preamble()."""
 

--- a/tests/translation/test_forward.py
+++ b/tests/translation/test_forward.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import pytest
 
-from translation.forward import anthropic_to_openai, translate_messages, translate_tools
+from translation.forward import anthropic_to_openai, translate_messages, translate_tools, _flatten_system
 
 from tests.translation.fixtures.anthropic_messages import (
     simple_text_message,
@@ -357,3 +357,180 @@ class TestParallelToolCalls:
         assert "compare" in assistant_msg["content"].lower()
         # Tool calls should also be present
         assert len(assistant_msg["tool_calls"]) == 2
+
+
+class TestFlattenSystem:
+    """Tests for _flatten_system() helper."""
+
+    def test_string_passthrough(self) -> None:
+        """String system prompt passes through unchanged."""
+        assert _flatten_system("Hello world.") == "Hello world."
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        assert _flatten_system("") == ""
+
+    def test_single_text_block(self) -> None:
+        """Single text content block flattens to its text."""
+        system = [{"type": "text", "text": "You are a coding assistant."}]
+        assert _flatten_system(system) == "You are a coding assistant."
+
+    def test_multiple_text_blocks_joined(self) -> None:
+        """Multiple text blocks are joined with double newlines."""
+        system = [
+            {"type": "text", "text": "First block."},
+            {"type": "text", "text": "Second block."},
+        ]
+        assert _flatten_system(system) == "First block.\n\nSecond block."
+
+    def test_empty_text_blocks_skipped(self) -> None:
+        """Empty text blocks are skipped."""
+        system = [
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "Content here."},
+        ]
+        assert _flatten_system(system) == "Content here."
+
+    def test_empty_list_returns_empty_string(self) -> None:
+        """Empty list returns empty string."""
+        assert _flatten_system([]) == ""
+
+    def test_non_text_blocks_skipped(self) -> None:
+        """Non-text blocks are skipped during flattening."""
+        system = [
+            {"type": "text", "text": "Instructions."},
+            {"type": "image", "source": {"data": "..."}},
+        ]
+        assert _flatten_system(system) == "Instructions."
+
+    def test_invalid_type_raises(self) -> None:
+        """Non-string non-list input raises TypeError."""
+        with pytest.raises(TypeError, match="Expected str or list"):
+            _flatten_system(123)  # type: ignore[arg-type]
+
+
+class TestListTypeSystemInForwardTranslation:
+    """Tests for anthropic_to_openai() handling list-type system field.
+
+    Claude Code sends system as a list of content blocks for
+    streaming/opus requests. This crashed in PR #19 because
+    strip_anthropic_identity() tried to run regex on a list.
+    """
+
+    def test_list_system_produces_system_message(self) -> None:
+        """List-type system field is flattened and becomes system role message."""
+        request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "system": [
+                {"type": "text", "text": "You are a coding assistant."},
+            ],
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        result = anthropic_to_openai(request)
+        system_msg = result["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "You are a coding assistant." in system_msg["content"]
+
+    def test_list_system_strips_identity(self) -> None:
+        """Identity patterns are stripped from list-type system blocks."""
+        request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "system": [
+                {
+                    "type": "text",
+                    "text": (
+                        "You are powered by the model named Claude Opus 4.6. "
+                        "The exact model ID is claude-opus-4-6."
+                    ),
+                },
+                {"type": "text", "text": "You are a coding assistant."},
+            ],
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        result = anthropic_to_openai(request)
+        system_msg = result["messages"][0]
+        assert "powered by the model named" not in system_msg["content"]
+        assert "claude-opus-4-6" not in system_msg["content"]
+        assert "You are a coding assistant." in system_msg["content"]
+
+    def test_list_system_includes_preamble(self) -> None:
+        """Preamble is prepended to flattened list-type system content."""
+        request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "system": [
+                {"type": "text", "text": "You are a coding assistant."},
+            ],
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        result = anthropic_to_openai(request)
+        system_msg = result["messages"][0]
+        assert "You are Grok" in system_msg["content"]
+        assert "Tool Preference Hierarchy" in system_msg["content"]
+        assert "You are a coding assistant." in system_msg["content"]
+
+    def test_list_system_realistic_claude_code_request(self) -> None:
+        """Realistic Claude Code streaming request with list-type system."""
+        request = {
+            "model": "claude-opus-4-20250514",
+            "max_tokens": 16384,
+            "stream": True,
+            "system": [
+                {
+                    "type": "text",
+                    "text": (
+                        "You are powered by the model named Claude Opus 4.6. "
+                        "The exact model ID is claude-opus-4-6.\n\n"
+                        "Assistant knowledge cutoff is May 2025.\n\n"
+                        "<claude_background_info>\n"
+                        "The most recent frontier Claude model is Claude Opus 4.6 "
+                        "(model ID: 'claude-opus-4-6').\n"
+                        "</claude_background_info>\n\n"
+                        "<fast_mode_info>\n"
+                        "Fast mode for Claude Code uses the same Claude Opus 4.6 "
+                        "model with faster output.\n"
+                        "</fast_mode_info>"
+                    ),
+                },
+                {
+                    "type": "text",
+                    "text": "You are an expert coding assistant.",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+            "messages": [
+                {"role": "user", "content": "Fix the bug in main.py"},
+            ],
+        }
+        result = anthropic_to_openai(request)
+        system_msg = result["messages"][0]
+        assert system_msg["role"] == "system"
+        # Identity claims stripped
+        assert "powered by" not in system_msg["content"]
+        assert "claude-opus" not in system_msg["content"]
+        assert "knowledge cutoff" not in system_msg["content"]
+        assert "claude_background_info" not in system_msg["content"]
+        # Preamble injected
+        assert "You are Grok" in system_msg["content"]
+        # Non-identity content preserved
+        assert "expert coding assistant" in system_msg["content"]
+        # Stream flag preserved
+        assert result["stream"] is True
+
+    def test_list_system_all_identity_blocks_produces_preamble_only(self) -> None:
+        """When all system blocks are identity-only, result is preamble only."""
+        request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "system": [
+                {"type": "text", "text": "You are powered by Claude Opus 4.6."},
+            ],
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        result = anthropic_to_openai(request)
+        system_msg = result["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "You are Grok" in system_msg["content"]
+        assert "powered by Claude" not in system_msg["content"]

--- a/translation/forward.py
+++ b/translation/forward.py
@@ -65,6 +65,29 @@ def strip_thinking(request: dict[str, Any]) -> list[str]:
     return warnings
 
 
+def _flatten_system(system: str | list[dict[str, Any]]) -> str:
+    """Flatten a system prompt to a single string.
+
+    Handles both Anthropic system prompt formats:
+    - String: returned as-is
+    - List of content blocks: text blocks are joined with newlines,
+      non-text blocks are skipped
+    """
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        parts: list[str] = []
+        for block in system:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                if text:
+                    parts.append(text)
+        return "\n\n".join(parts)
+    raise TypeError(
+        f"Expected str or list for system field, got {type(system).__name__}"
+    )
+
+
 def anthropic_to_openai(request: dict[str, Any]) -> dict[str, Any]:
     """Translate a full Anthropic Messages API request to OpenAI format."""
     for feature in UNSUPPORTED_FEATURES:
@@ -77,8 +100,12 @@ def anthropic_to_openai(request: dict[str, Any]) -> dict[str, Any]:
     messages: list[dict[str, Any]] = []
 
     # System prompt: top-level field -> system role message
-    # Strip Anthropic identity claims before prepending our preamble
-    system = strip_anthropic_identity(request.get("system", ""))
+    # The Anthropic API sends system as either a string or a list of
+    # content blocks (e.g. [{"type": "text", "text": "..."}]).
+    # Strip Anthropic identity claims, then flatten to a string for OpenAI.
+    raw_system = request.get("system", "")
+    stripped = strip_anthropic_identity(raw_system)
+    system = _flatten_system(stripped)
     preamble = _config.system_prompt_preamble
     if preamble and system:
         system = f"{preamble}\n\n{system}"


### PR DESCRIPTION
## Summary

- **Root cause**: Anthropic Messages API sends `system` as either a string or a list of content blocks (`[{"type": "text", "text": "..."}]`). Claude Code uses the list format for streaming/opus requests. `strip_anthropic_identity()` ran `pattern.sub()` directly on the value, crashing with `TypeError: expected string or bytes-like object, got 'list'` at line 172.
- **Fix**: `strip_anthropic_identity()` now handles both `str` and `list[dict]` types. For lists, it iterates blocks, applies regex to `{"type": "text"}` blocks, and removes blocks that become empty after stripping.
- **Secondary fix**: Regex patterns for "You are powered by Claude Opus 4.6" used `[^\n.]` which excluded the dot in version numbers like `4.6`, leaving a "6." residual. Changed to `[^\n]*?(?:\.\s+|\.\s*$)` which correctly matches to end-of-sentence periods.
- **Forward translation**: Added `_flatten_system()` helper in `forward.py` to convert list-type system to string after identity stripping, before preamble prepend.
- **24 new tests** covering both system types (string and list of content blocks) across `strip_anthropic_identity()`, `_flatten_system()`, and `anthropic_to_openai()`.

**Total**: 369 tests passing (was 345 before this PR).

## Files Changed

| File | Change |
|------|--------|
| `enrichment/system_preamble.py` | Handle list-type system, extract `_strip_text()`, fix regex |
| `translation/forward.py` | Add `_flatten_system()`, update system handling in `anthropic_to_openai()` |
| `tests/enrichment/test_system_preamble.py` | 11 new tests for list-type stripping |
| `tests/translation/test_forward.py` | 13 new tests for flatten + list-type forward translation |

## Test plan

- [x] All 369 tests pass (`python3 -m pytest -v`)
- [x] String-type system still works (all existing tests pass)
- [x] List-type system with identity patterns stripped correctly
- [x] List-type system with empty blocks after stripping removed
- [x] List-type system preserves non-text block metadata (cache_control)
- [x] Realistic Claude Code streaming request with list system works end-to-end
- [x] TypeError raised for invalid system types (not string, not list)

Generated with [Claude Code](https://claude.com/claude-code)