### PR TITLE
Quiet thinking-stripped notice to DEBUG level

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ async def messages(request: Request):
         bridge_warnings = strip_thinking(body)
         if bridge_warnings:
             for w in bridge_warnings:
-                logger.info("Degraded feature: %s", w)
+                logger.debug("Degraded feature: %s", w)
 
         openai_body = anthropic_to_openai(body)
 


### PR DESCRIPTION
## Summary
- Move "Degraded feature: thinking parameter stripped" log from INFO to DEBUG in `main.py` line 73
- The `X-Bridge-Warning` HTTP header is unchanged -- programmatic consumers still see the notice
- This fires on every request since Claude Code always sends the `thinking` parameter, cluttering Dan's live output

## Test plan
- [x] All 369 tests pass (`python3 -m pytest -v`)
- [x] Verified `X-Bridge-Warning` header logic is untouched (lines 119-120, 159-160)

🤖 Generated with [Claude Code](https://claude.com/claude-code)