### PR TITLE
Fix escaped newlines in response text

### DIFF
--- a/tests/translation/test_newline_unescape.py
+++ b/tests/translation/test_newline_unescape.py
@@ -1,0 +1,473 @@
+"""Tests for newline unescaping in response text.
+
+Verifies that literal escape sequences (backslash-n, backslash-t) in Grok's
+response text are converted to real control characters before reaching Claude
+Code. This fixes the "escaped newlines in plan output" bug where Grok returns
+text with literal \\n instead of actual newline characters.
+
+Coverage:
+1. unescape_text() function directly
+2. Non-streaming reverse translation (_build_content)
+3. Streaming translation (adapter and stateless)
+4. Tool call arguments are NOT unescaped (structured data)
+5. E2E round trip through JSONResponse
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, AsyncIterator
+
+import pytest
+
+from translation.reverse import unescape_text, openai_to_anthropic
+from translation.streaming import (
+    translate_sse_event,
+    OpenAIToAnthropicStreamAdapter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _completion_with_content(content: str) -> dict[str, Any]:
+    """Build an OpenAI completion response with the given content text."""
+    return {
+        "id": "chatcmpl-newline-test",
+        "object": "chat.completion",
+        "created": 1709000000,
+        "model": "grok-4-1-fast-reasoning",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+
+def _streaming_chunk_with_content(content: str) -> dict[str, Any]:
+    """Build an OpenAI streaming chunk with the given delta content."""
+    return {
+        "id": "chatcmpl-stream-nl",
+        "object": "chat.completion.chunk",
+        "created": 1709000300,
+        "model": "grok-4-1-fast-reasoning",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": content},
+                "finish_reason": None,
+            }
+        ],
+    }
+
+
+async def _lines_to_async_iter(lines: list[str]) -> AsyncIterator[str]:
+    for line in lines:
+        yield line
+
+
+async def _collect_events(adapter: OpenAIToAnthropicStreamAdapter) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for event in adapter:
+        events.append(event)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# unescape_text() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnescapeText:
+    """Direct tests for the unescape_text function."""
+
+    def test_literal_newline_converted(self) -> None:
+        """Literal backslash-n becomes a real newline."""
+        assert unescape_text("Step 1\\nStep 2") == "Step 1\nStep 2"
+
+    def test_literal_tab_converted(self) -> None:
+        """Literal backslash-t becomes a real tab."""
+        assert unescape_text("col1\\tcol2") == "col1\tcol2"
+
+    def test_literal_carriage_return_converted(self) -> None:
+        """Literal backslash-r becomes a real carriage return."""
+        assert unescape_text("line1\\rline2") == "line1\rline2"
+
+    def test_multiple_newlines(self) -> None:
+        """Multiple literal newlines are all converted."""
+        text = "1. First\\n2. Second\\n3. Third"
+        expected = "1. First\n2. Second\n3. Third"
+        assert unescape_text(text) == expected
+
+    def test_mixed_escape_sequences(self) -> None:
+        """Mixed literal escapes (newline + tab) are all converted."""
+        text = "Header\\n\\tIndented line\\nNext line"
+        expected = "Header\n\tIndented line\nNext line"
+        assert unescape_text(text) == expected
+
+    def test_already_real_newlines_preserved(self) -> None:
+        """Text that already has real newlines is passed through unchanged."""
+        text = "Step 1\nStep 2\nStep 3"
+        assert unescape_text(text) == text
+
+    def test_no_backslash_passthrough(self) -> None:
+        """Text with no backslashes at all returns fast-path unchanged."""
+        text = "Hello, World!"
+        assert unescape_text(text) == text
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        assert unescape_text("") == ""
+
+    def test_double_backslash_not_corrupted(self) -> None:
+        r"""Actual double-backslash followed by n (\\n) is not unescaped.
+
+        When the model outputs a literal \\n (to show an escape sequence
+        in code), the double backslash means "literal backslash" and the
+        n is just 'n'. The negative lookbehind prevents unescaping.
+        """
+        # In Python source: "\\\\n" is the string \\n (two chars: \ and n preceded by \)
+        text = "print(\\\\n)"
+        # The lookbehind sees the preceding backslash and skips
+        result = unescape_text(text)
+        # Should NOT convert to a real newline
+        assert "\\n" in result
+
+    def test_real_newline_mixed_with_literal(self) -> None:
+        """Text with both real and literal newlines: only literals converted."""
+        text = "Real newline here\nLiteral here\\nDone"
+        expected = "Real newline here\nLiteral here\nDone"
+        assert unescape_text(text) == expected
+
+    def test_plan_output_realistic(self) -> None:
+        """Realistic plan output from Grok with literal newlines throughout."""
+        text = (
+            "Here is my plan:\\n"
+            "\\n"
+            "1. Read the configuration file\\n"
+            "2. Parse the settings\\n"
+            "3. Apply changes\\n"
+            "\\n"
+            "Let me start with step 1."
+        )
+        expected = (
+            "Here is my plan:\n"
+            "\n"
+            "1. Read the configuration file\n"
+            "2. Parse the settings\n"
+            "3. Apply changes\n"
+            "\n"
+            "Let me start with step 1."
+        )
+        assert unescape_text(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming reverse translation
+# ---------------------------------------------------------------------------
+
+
+class TestNonStreamingNewlines:
+    """Multiline content through the non-streaming reverse translator."""
+
+    def test_literal_newlines_in_response_unescaped(self) -> None:
+        """Literal \\n in Grok response text becomes real newlines."""
+        response = _completion_with_content("Step 1\\nStep 2\\nStep 3")
+        result = openai_to_anthropic(response)
+        text = result["content"][0]["text"]
+        assert text == "Step 1\nStep 2\nStep 3"
+        assert text.count("\n") == 2
+
+    def test_real_newlines_preserved(self) -> None:
+        """Real newlines in Grok response pass through correctly."""
+        response = _completion_with_content("Step 1\nStep 2\nStep 3")
+        result = openai_to_anthropic(response)
+        text = result["content"][0]["text"]
+        assert text == "Step 1\nStep 2\nStep 3"
+        assert text.count("\n") == 2
+
+    def test_tool_call_arguments_not_unescaped(self) -> None:
+        """Tool call JSON arguments are NOT run through unescape_text.
+
+        Tool arguments are structured JSON data parsed by json.loads().
+        The unescape_text function is only applied to display text content,
+        never to parsed tool argument values.
+        """
+        # Build arguments JSON where the string value contains a real newline
+        # (which is what json.loads produces from "hello\\nworld" in JSON)
+        args_json = '{"file_path": "/tmp/test.py", "content": "line1\\nline2"}'
+        response = {
+            "id": "chatcmpl-tool-nl",
+            "object": "chat.completion",
+            "created": 1709000000,
+            "model": "grok-4-1-fast-reasoning",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_nl_test",
+                                "type": "function",
+                                "function": {
+                                    "name": "Write",
+                                    "arguments": args_json,
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        }
+        result = openai_to_anthropic(response)
+        tool_block = next(b for b in result["content"] if b["type"] == "tool_use")
+        # json.loads converts \\n in JSON to a real newline in the string value.
+        # The tool input should contain exactly what json.loads produced.
+        assert tool_block["input"]["content"] == "line1\nline2"
+        # Verify unescape_text was NOT applied (it would be a no-op here
+        # since the value already has real newlines, but the point is the
+        # code path does not call it for tool arguments)
+
+    def test_multiline_plan_e2e(self) -> None:
+        """Full plan with multiple paragraphs renders with real newlines."""
+        # Each \\n in the Python string literal is a literal backslash-n
+        # (two characters), simulating what Grok sends.
+        plan = (
+            "## Implementation Plan\\n"
+            "\\n"
+            "### Phase 1: Research\\n"
+            "- Read existing code\\n"
+            "- Identify dependencies\\n"
+            "\\n"
+            "### Phase 2: Implementation\\n"
+            "- Create new module\\n"
+            "- Write tests\\n"
+            "\\n"
+            "### Phase 3: Review\\n"
+            "- Run test suite\\n"
+            "- Create PR"
+        )
+        response = _completion_with_content(plan)
+        result = openai_to_anthropic(response)
+        text = result["content"][0]["text"]
+
+        # All literal \n sequences should be converted to real newlines
+        assert "## Implementation Plan\n" in text
+        assert "### Phase 1: Research\n" in text
+        assert "- Read existing code\n" in text
+        # Count: 11 literal \n in the input, plus none from Python string concat
+        # The plan has: Plan\n, \n, Phase1\n, read\n, deps\n, \n, Phase2\n,
+        # module\n, tests\n, \n, Phase3\n, suite\n = 12 literal \n sequences
+        assert text.count("\n") == 12
+
+
+# ---------------------------------------------------------------------------
+# Streaming translation
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingNewlines:
+    """Multiline content through the streaming translator."""
+
+    def test_stateless_literal_newline_unescaped(self) -> None:
+        """translate_sse_event unescapes literal \\n in text deltas."""
+        chunk = _streaming_chunk_with_content("Hello\\nWorld")
+        events = translate_sse_event(chunk, is_first=False)
+
+        text_deltas = [
+            e for e in events
+            if e["type"] == "content_block_delta"
+            and e["delta"]["type"] == "text_delta"
+        ]
+        assert len(text_deltas) == 1
+        assert text_deltas[0]["delta"]["text"] == "Hello\nWorld"
+
+    def test_stateless_real_newline_preserved(self) -> None:
+        """translate_sse_event preserves real newlines in text deltas."""
+        chunk = _streaming_chunk_with_content("Hello\nWorld")
+        events = translate_sse_event(chunk, is_first=False)
+
+        text_deltas = [
+            e for e in events
+            if e["type"] == "content_block_delta"
+            and e["delta"]["type"] == "text_delta"
+        ]
+        assert len(text_deltas) == 1
+        assert text_deltas[0]["delta"]["text"] == "Hello\nWorld"
+
+    @pytest.mark.asyncio
+    async def test_adapter_literal_newlines_unescaped(self) -> None:
+        """The stream adapter unescapes literal \\n in assembled text."""
+        chunks = [
+            {
+                "id": "chatcmpl-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000300,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000300,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{"index": 0, "delta": {"content": "Step 1\\nStep 2"}, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000300,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{"index": 0, "delta": {"content": "\\nStep 3"}, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000300,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            },
+        ]
+        lines = [f"data: {json.dumps(c)}" for c in chunks]
+        lines.append("data: [DONE]")
+
+        source = _lines_to_async_iter(lines)
+        adapter = OpenAIToAnthropicStreamAdapter(source)
+        events = await _collect_events(adapter)
+
+        text_deltas = [
+            e for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        full_text = "".join(d["delta"]["text"] for d in text_deltas)
+        assert full_text == "Step 1\nStep 2\nStep 3"
+        assert full_text.count("\n") == 2
+
+    @pytest.mark.asyncio
+    async def test_adapter_tool_arguments_not_unescaped(self) -> None:
+        """Tool call arguments in streaming are NOT unescaped.
+
+        The input_json_delta events pass through raw partial JSON strings.
+        unescape_text is only applied to text_delta events.
+        """
+        chunks = [
+            {
+                "id": "chatcmpl-tool-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000400,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "index": 0,
+                            "id": "call_stream_nl",
+                            "type": "function",
+                            "function": {"name": "Write", "arguments": ""},
+                        }],
+                    },
+                    "finish_reason": None,
+                }],
+            },
+            {
+                "id": "chatcmpl-tool-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000400,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "function": {"arguments": '{"content": "line1\\nline2"}'},
+                        }],
+                    },
+                    "finish_reason": None,
+                }],
+            },
+            {
+                "id": "chatcmpl-tool-nl-stream",
+                "object": "chat.completion.chunk",
+                "created": 1709000400,
+                "model": "grok-4-1-fast-reasoning",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            },
+        ]
+        lines = [f"data: {json.dumps(c)}" for c in chunks]
+        lines.append("data: [DONE]")
+
+        source = _lines_to_async_iter(lines)
+        adapter = OpenAIToAnthropicStreamAdapter(source)
+        events = await _collect_events(adapter)
+
+        json_deltas = [
+            e for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "input_json_delta"
+        ]
+        # Tool arguments are raw partial JSON strings — NOT processed by
+        # unescape_text. The consumer assembles and parses them.
+        full_json = "".join(d["delta"]["partial_json"] for d in json_deltas)
+        parsed = json.loads(full_json)
+        # json.loads converts \n in JSON to a real newline — that's correct
+        # JSON parsing behavior, not our unescape function
+        assert parsed["content"] == "line1\nline2"
+
+
+# ---------------------------------------------------------------------------
+# SSE wire format round trip
+# ---------------------------------------------------------------------------
+
+
+class TestSSEWireFormat:
+    """Verify newlines survive the SSE serialization round trip."""
+
+    def test_real_newline_in_sse_json(self) -> None:
+        """A real newline in text survives json.dumps -> SSE data line -> json.loads."""
+        event = {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Line 1\nLine 2"},
+        }
+        sse_line = f"data: {json.dumps(event)}"
+
+        # Verify the SSE line is valid (no raw newlines breaking the format)
+        assert sse_line.count("\n") == 0, "SSE data line must not contain raw newlines"
+
+        # Verify round trip
+        payload = sse_line[6:]
+        recovered = json.loads(payload)
+        assert recovered["delta"]["text"] == "Line 1\nLine 2"
+
+    def test_multiline_plan_sse_round_trip(self) -> None:
+        """A full multiline plan text survives SSE serialization."""
+        plan_text = "Plan:\n1. Step one\n2. Step two\n3. Step three\n\nDone."
+        event = {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": plan_text},
+        }
+        sse_line = f"data: {json.dumps(event)}"
+
+        # No raw newlines in the SSE data line
+        assert "\n" not in sse_line.split("data: ", 1)[1].replace("\\n", "")
+
+        # Full round trip
+        recovered = json.loads(sse_line[6:])
+        assert recovered["delta"]["text"] == plan_text
+        assert recovered["delta"]["text"].count("\n") == 5

--- a/translation/__init__.py
+++ b/translation/__init__.py
@@ -6,7 +6,7 @@ enrichment injection hooks at every boundary.
 """
 
 from translation.forward import anthropic_to_openai, translate_messages, translate_tools, strip_thinking
-from translation.reverse import openai_to_anthropic, translate_response
+from translation.reverse import openai_to_anthropic, translate_response, unescape_text
 from translation.streaming import translate_sse_event, OpenAIToAnthropicStreamAdapter
 from translation.config import TranslationConfig
 
@@ -17,6 +17,7 @@ __all__ = [
     "strip_thinking",
     "openai_to_anthropic",
     "translate_response",
+    "unescape_text",
     "translate_sse_event",
     "OpenAIToAnthropicStreamAdapter",
     "TranslationConfig",

--- a/translation/reverse.py
+++ b/translation/reverse.py
@@ -7,6 +7,7 @@ tool_use blocks, stop_reason mapping, usage translation, error formatting.
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from typing import Any
 
@@ -15,6 +16,32 @@ from translation.config import TranslationConfig, STOP_REASON_MAP
 
 _config = TranslationConfig()
 logger = get_logger("reverse")
+
+# Pattern to match literal escape sequences that should be real control chars.
+# Matches \n, \t, \r that are NOT preceded by an actual backslash (negative
+# lookbehind ensures we don't corrupt already-escaped sequences like \\n).
+_ESCAPE_MAP: dict[str, str] = {
+    r"\n": "\n",
+    r"\t": "\t",
+    r"\r": "\r",
+}
+_LITERAL_ESCAPE_RE = re.compile(r"(?<!\\)\\([ntr])")
+
+
+def unescape_text(text: str) -> str:
+    """Unescape literal backslash-n/t/r sequences in model output text.
+
+    xAI/Grok may return text with literal two-character escape sequences
+    (backslash + n) instead of actual newline characters. This converts
+    them to real control characters so Claude Code renders them correctly.
+
+    Only applied to display text, never to tool call arguments.
+    """
+    if "\\" not in text:
+        return text
+    return _LITERAL_ESCAPE_RE.sub(
+        lambda m: _ESCAPE_MAP[m.group(0)], text
+    )
 
 _ERROR_TYPE_MAP: dict[str, str] = {
     "rate_limit_error": "rate_limit_error",
@@ -75,7 +102,7 @@ def _build_content(message: dict[str, Any]) -> list[dict[str, Any]]:
     tool_calls = message.get("tool_calls")
 
     if text is not None:
-        content.append({"type": "text", "text": text})
+        content.append({"type": "text", "text": unescape_text(text)})
     elif not tool_calls:
         content.append({"type": "text", "text": ""})
 

--- a/translation/streaming.py
+++ b/translation/streaming.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json, uuid
 from typing import Any, AsyncIterator
 from translation.config import STOP_REASON_MAP
+from translation.reverse import unescape_text
 
 
 def _msg_start(chunk: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -44,7 +45,7 @@ def translate_sse_event(chunk: dict[str, Any], is_first: bool = False, is_last: 
         evts.append(_msg_start(chunk))
     text = delta.get("content")
     if text is not None and text != "":
-        evts.append({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": text}})
+        evts.append({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": unescape_text(text)}})
     for tc in delta.get("tool_calls", []):
         evts.extend(_tool_events(tc))
     if is_last or finish is not None:
@@ -111,7 +112,7 @@ class OpenAIToAnthropicStreamAdapter:
                 ev.append({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}})
                 self._bopen = True
             if text != "":
-                ev.append({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": text}})
+                ev.append({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": unescape_text(text)}})
         for tc in delta.get("tool_calls", []):
             if tc.get("id") and self._bopen:
                 ev.append({"type": "content_block_stop", "index": 0})


### PR DESCRIPTION
## Summary

Fixes #24 — literal `\n` characters appear instead of actual newlines when Grok outputs plans or multiline text via Claude Code.

- Added `unescape_text()` function in `translation/reverse.py` that converts literal `\n`, `\t`, `\r` escape sequences to real control characters
- Applied in non-streaming path (`_build_content`) and streaming path (`translate_sse_event` + adapter `_xlate`)
- Uses negative lookbehind regex to protect double-backslash sequences (`\\n` in code stays as-is)
- Tool call arguments (structured JSON data) are **never** unescaped — only display text content

## Test plan

- [x] 11 unit tests for `unescape_text()` — literal newlines, tabs, carriage returns, mixed sequences, double backslash protection, empty strings, fast path
- [x] 4 non-streaming reverse translation tests — literal vs real newlines, tool argument preservation, realistic multiline plan
- [x] 4 streaming translation tests — stateless event, adapter assembled text, tool argument passthrough
- [x] 2 SSE wire format round-trip tests — JSON encoding/decoding preserves newlines
- [x] All 390 existing tests still pass (zero regressions)

## Files changed

| File | Change |
|------|--------|
| `translation/reverse.py` | Added `unescape_text()`, applied in `_build_content()` |
| `translation/streaming.py` | Import + apply `unescape_text()` in text delta paths |
| `translation/__init__.py` | Export `unescape_text` |
| `tests/translation/test_newline_unescape.py` | 21 new tests |

Generated with [Claude Code](https://claude.com/claude-code)