### PR TITLE
feat: fill structural YAML coverage gaps — 9/9 tools on all patterns (#27)

### DIFF
--- a/structure/structural/anti_patterns.yaml
+++ b/structure/structural/anti_patterns.yaml
@@ -47,3 +47,36 @@ tools:
     - anti_pattern: Using Bash find instead of Glob
       why_bad: Slower and loses integration with the tool system
       do_instead: Use Glob with pattern matching
+
+  WebFetch:
+    - anti_pattern: Fetching authenticated or private URLs
+      why_bad: Will fail silently or return login pages instead of content
+      do_instead: Use gh CLI for GitHub, or specialized tools for authenticated services
+    - anti_pattern: Fetching without checking if a specialized tool exists
+      why_bad: GitHub, Jira, and other services have dedicated tools that work better
+      do_instead: Check for gh CLI, MCP tools, or other service-specific integrations first
+    - anti_pattern: Not handling redirect responses
+      why_bad: Cross-host redirects return a redirect URL instead of content
+      do_instead: Check the response for redirect_url and make a follow-up request
+
+  WebSearch:
+    - anti_pattern: Searching the web when the answer is in local files
+      why_bad: Wastes time and may return irrelevant results when Grep/Read would be faster
+      do_instead: Search the codebase first with Grep, then fall back to WebSearch
+    - anti_pattern: Using overly broad search queries
+      why_bad: Returns too many irrelevant results, wastes context on noise
+      do_instead: Use specific keywords, add year for recent info, use domain filters
+    - anti_pattern: Omitting the Sources section after using search results
+      why_bad: Violates the mandatory requirement to cite sources with URLs
+      do_instead: Always include a Sources section with markdown hyperlinks at the end
+
+  NotebookEdit:
+    - anti_pattern: Editing a notebook without reading it first
+      why_bad: Cell indices and content are unknown — edits will target wrong cells
+      do_instead: Always Read the .ipynb file first to understand cell structure
+    - anti_pattern: Using Write or Edit on .ipynb files instead of NotebookEdit
+      why_bad: Destroys notebook metadata, cell outputs, and kernel state
+      do_instead: Use NotebookEdit for all Jupyter notebook modifications
+    - anti_pattern: Using wrong cell index (forgetting 0-indexing)
+      why_bad: Edits the wrong cell — cell_number 1 is the second cell, not the first
+      do_instead: Remember cell_number is 0-indexed and verify with Read first

--- a/structure/structural/errors.yaml
+++ b/structure/structural/errors.yaml
@@ -29,3 +29,41 @@ tools:
       suggestion: Increase timeout parameter (max 600000ms) or use run_in_background
     - error: Command failed
       suggestion: Check that file paths with spaces are double-quoted
+
+  Glob:
+    - error: No matches found
+      suggestion: Try a broader pattern or verify the directory path exists
+    - error: Invalid glob pattern
+      suggestion: Check pattern syntax — use ** for recursive matching, * for single-level
+
+  Grep:
+    - error: No matches found
+      suggestion: Try a broader regex pattern or different file type filter
+    - error: Invalid regex pattern
+      suggestion: Check regex syntax — literal braces need escaping with backslash
+
+  WebFetch:
+    - error: URL not reachable
+      suggestion: Verify the URL is valid and publicly accessible — authenticated URLs will fail
+    - error: Redirect to different host
+      suggestion: Make a new WebFetch request using the redirect URL provided in the response
+    - error: Content too large
+      suggestion: Try a more specific page URL or use WebSearch to find a smaller source
+    - error: Authentication required
+      suggestion: This URL requires login — use gh CLI for GitHub or specialized tools for other services
+
+  WebSearch:
+    - error: Query too broad
+      suggestion: Add specific keywords, dates, or domain filters to narrow results
+    - error: No results found
+      suggestion: Try alternative search terms or check spelling
+    - error: Rate limited
+      suggestion: Wait briefly before retrying — consider caching previous results
+
+  NotebookEdit:
+    - error: Cell not found
+      suggestion: Use Read on the notebook to check cell count — cell_number is 0-indexed
+    - error: Invalid cell type
+      suggestion: cell_type must be "code" or "markdown"
+    - error: Notebook path not found
+      suggestion: Use Glob to locate the .ipynb file — notebook_path must be absolute

--- a/structure/structural/hateoas.yaml
+++ b/structure/structural/hateoas.yaml
@@ -53,3 +53,28 @@ tools:
       - Grep
     on_error:
       no_matches: Try a broader pattern or check the directory path
+
+  WebFetch:
+    related:
+      - WebSearch
+      - Read
+    on_error:
+      url_unreachable: Check the URL is valid and publicly accessible
+      redirect_loop: Use the redirect URL provided in the error response
+      content_too_large: Try a more specific page URL or use WebSearch to find a better source
+
+  WebSearch:
+    related:
+      - WebFetch
+      - Read
+    on_error:
+      no_results: Try broader or alternative search terms
+      rate_limited: Wait briefly and retry with a more focused query
+
+  NotebookEdit:
+    related:
+      - Read
+      - Write
+    on_error:
+      cell_not_found: Use Read to check the notebook cell count and indices
+      notebook_not_found: Use Glob to locate the .ipynb file first

--- a/structure/structural/near_miss.yaml
+++ b/structure/structural/near_miss.yaml
@@ -61,3 +61,37 @@ tools:
       - exec
       - run
     commonly_confused_with: []
+
+  WebFetch:
+    aliases:
+      - fetch
+      - curl
+      - wget
+      - download
+      - http_get
+    commonly_confused_with:
+      - Bash curl
+      - Bash wget
+      - WebSearch
+
+  WebSearch:
+    aliases:
+      - search
+      - google
+      - web_search
+      - find_online
+      - lookup
+    commonly_confused_with:
+      - Grep
+      - WebFetch
+
+  NotebookEdit:
+    aliases:
+      - jupyter
+      - notebook
+      - ipynb
+      - cell_edit
+      - notebook_write
+    commonly_confused_with:
+      - Write
+      - Edit

--- a/structure/structural/quality_gates.yaml
+++ b/structure/structural/quality_gates.yaml
@@ -41,3 +41,48 @@ tools:
     quality:
       reliability: high
       engine: ripgrep
+
+  Write:
+    warnings:
+      - Overwrites the entire file — all content not included in your write is lost
+      - Must Read existing files before overwriting them
+      - Never proactively create documentation files unless explicitly requested
+    quality:
+      reliability: high
+      safety: destructive to existing content — prefer Edit for modifications
+
+  Glob:
+    warnings:
+      - Returns paths sorted by modification time, not alphabetically
+      - Does not search file contents — use Grep for content matching
+    quality:
+      reliability: high
+      coverage: any file system pattern
+
+  WebFetch:
+    warnings:
+      - Authenticated or private URLs will fail without clear error
+      - HTTP URLs are automatically upgraded to HTTPS
+      - Content from very large pages may be summarized or truncated
+      - 15-minute cache means repeated fetches may return stale content
+    quality:
+      reliability: medium
+      dependency: external network and target site availability
+
+  WebSearch:
+    warnings:
+      - Results may not reflect the most recent information
+      - Always use the current year in search queries for recent data
+      - Must include Sources section with URLs in the response
+    quality:
+      reliability: medium
+      dependency: external search service availability
+
+  NotebookEdit:
+    warnings:
+      - Cell numbering is 0-indexed — first cell is cell_number 0
+      - Must Read the notebook first to understand cell structure
+      - cell_type is required when using edit_mode=insert
+    quality:
+      reliability: high
+      coverage: code and markdown cell types

--- a/structure/structural/self_describing.yaml
+++ b/structure/structural/self_describing.yaml
@@ -56,3 +56,41 @@ tools:
         items:
           type: string
         description: Matching file paths sorted by modification time
+
+  WebFetch:
+    type: object
+    properties:
+      content:
+        type: string
+        description: Processed content from the URL, converted from HTML to markdown
+      redirect_url:
+        type: string
+        description: Redirect URL if the request was redirected to a different host
+
+  WebSearch:
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          type: object
+          properties:
+            title:
+              type: string
+            url:
+              type: string
+            snippet:
+              type: string
+        description: Search results with titles, URLs, and text snippets
+
+  NotebookEdit:
+    type: object
+    properties:
+      success:
+        type: boolean
+      cell_number:
+        type: integer
+        description: The 0-indexed cell number that was edited, inserted, or deleted
+      edit_mode:
+        type: string
+        description: The operation performed — replace, insert, or delete


### PR DESCRIPTION
## Summary
Extends Nexus's StructureLoader YAML files (PR #30) to fill coverage gaps. All 6 structural patterns now have entries for all 9 Claude Code tools.

## Changes

All changes are in `structure/structural/` — YAML files only, no Python modifications.

| File | Tools Before | Tools After | Added |
|------|-------------|-------------|-------|
| `hateoas.yaml` | 6 | 9 | WebFetch, WebSearch, NotebookEdit |
| `errors.yaml` | 4 | 9 | Glob, Grep, WebFetch, WebSearch, NotebookEdit |
| `near_miss.yaml` | 6 | 9 | WebFetch, WebSearch, NotebookEdit |
| `self_describing.yaml` | 6 | 9 | WebFetch, WebSearch, NotebookEdit |
| `quality_gates.yaml` | 4 | 9 | Write, Glob, WebFetch, WebSearch, NotebookEdit |
| `anti_patterns.yaml` | 6 | 9 | WebFetch, WebSearch, NotebookEdit |

## Why
Shipping incomplete coverage creates tech debt we'd immediately circle back to (Nexus's recommendation, agreed). The YAML extraction touched these files anyway — filling gaps now prevents a second pass.

## Test Results
495 tests pass. Zero regressions.

## References
- Extends #27 (dynamic enrichment)
- Builds on PR #30 (StructureLoader)
- Reviewer: @nexus-marbell

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)