### PR TITLE
fix: post-sprint cleanup — env example, dead code, token log model name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ HOST=0.0.0.0
 PORT=4000
 ENRICHMENT_MODE=full           # passthrough | structural | full
 PREAMBLE_ENABLED=true          # false to disable system prompt behavioral injection
+IDENTITY_ENABLED=true          # false to disable Grok identity assertion and Claude identity stripping
+LOG_LEVEL=INFO                 # DEBUG, INFO, WARNING, ERROR — controls bridge.* logger hierarchy
+DUMP_REQUESTS=false            # true to write full request/response JSON to DUMP_DIR for debugging
+DUMP_DIR=./dumps               # directory for request/response JSON dumps when DUMP_REQUESTS=true

--- a/bridge/token_logger.py
+++ b/bridge/token_logger.py
@@ -20,16 +20,6 @@ from bridge.logging_config import get_logger
 logger = get_logger("tokens")
 
 
-def estimate_tokens(text: str) -> int:
-    """Estimate token count from character length.
-
-    Uses the standard approximation of ~4 characters per token for
-    English text and code. This is not exact but sufficient for
-    logging purposes without adding a tokenizer dependency.
-    """
-    return max(1, len(text) // 4)
-
-
 def measure_enrichment_overhead(
     original_tools: list[dict[str, Any]],
     enriched_tools: list[dict[str, Any]],
@@ -60,6 +50,7 @@ def log_token_usage(
     enrichment_overhead_tokens: int = 0,
     elapsed_seconds: float = 0.0,
     is_streaming: bool = False,
+    model: str = "",
 ) -> dict[str, Any]:
     """Log token counts for a completed request.
 
@@ -72,6 +63,7 @@ def log_token_usage(
         enrichment_overhead_tokens: Estimated tokens added by enrichment.
         elapsed_seconds: Total request time in seconds.
         is_streaming: Whether this was a streaming request.
+        model: The resolved model name used for this request.
     """
     total_tokens = input_tokens + output_tokens
     mode = "stream" if is_streaming else "sync"
@@ -84,8 +76,9 @@ def log_token_usage(
     }
 
     logger.info(
-        "Token usage: input=%d output=%d total=%d "
+        "Token usage: model=%s input=%d output=%d total=%d "
         "enrichment_overhead=%d mode=%s elapsed=%.2fs",
+        model or "unknown",
         input_tokens,
         output_tokens,
         total_tokens,

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ async def messages(request: Request):
         headers = {"Authorization": f"Bearer {XAI_API_KEY}", "Content-Type": "application/json"}
 
         if openai_body.get("stream"):
-            return await _stream(openai_body, headers, bridge_warnings, start)
+            return await _stream(openai_body, headers, bridge_warnings, start, model=openai_body.get("model", ""))
 
         resp = await client.post("/chat/completions", json=openai_body, headers=headers)
         data = resp.json()
@@ -115,6 +115,7 @@ async def messages(request: Request):
             enrichment_overhead_tokens=get_last_enrichment_overhead(),
             elapsed_seconds=elapsed,
             is_streaming=False,
+            model=openai_body.get("model", ""),
         )
 
         # -- Point 3: Full response at DEBUG --
@@ -147,6 +148,7 @@ async def messages(request: Request):
 async def _stream(
     openai_body: dict, headers: dict[str, str],
     bridge_warnings: list[str] | None = None, start_time: float = 0,
+    model: str = "",
 ) -> StreamingResponse:
     event_count = 0
     enrichment_overhead = get_last_enrichment_overhead()
@@ -175,6 +177,7 @@ async def _stream(
                 enrichment_overhead_tokens=enrichment_overhead,
                 elapsed_seconds=elapsed,
                 is_streaming=True,
+                model=model,
             )
 
     response_headers = {}

--- a/structure/manifest.yaml
+++ b/structure/manifest.yaml
@@ -1,4 +1,5 @@
 schema_version: "1.0"
+type: manifest
 description: >
   Master index of all enrichment pattern definitions.
   Each entry maps to a YAML file in the corresponding subdirectory.

--- a/tests/bridge/test_token_integration.py
+++ b/tests/bridge/test_token_integration.py
@@ -171,7 +171,6 @@ class TestEnrichmentOverheadTracking:
             set_tool_enrichment_hook,
         )
         # Clear hook
-        original_hook = None
         try:
             set_tool_enrichment_hook(None)
             tools = [{"name": "Read", "description": "R", "input_schema": {"type": "object"}}]

--- a/tests/bridge/test_token_logger.py
+++ b/tests/bridge/test_token_logger.py
@@ -12,28 +12,9 @@ from typing import Any
 import pytest
 
 from bridge.token_logger import (
-    estimate_tokens,
     log_token_usage,
     measure_enrichment_overhead,
 )
-
-
-class TestEstimateTokens:
-    """Token estimation from character count."""
-
-    def test_empty_string_returns_one(self) -> None:
-        assert estimate_tokens("") == 1
-
-    def test_short_text(self) -> None:
-        # 12 chars -> 3 tokens
-        assert estimate_tokens("hello world!") == 3
-
-    def test_longer_text(self) -> None:
-        text = "a" * 400
-        assert estimate_tokens(text) == 100
-
-    def test_single_char_returns_one(self) -> None:
-        assert estimate_tokens("x") == 1
 
 
 class TestMeasureEnrichmentOverhead:
@@ -114,14 +95,27 @@ class TestLogTokenUsage:
                 enrichment_overhead_tokens=20,
                 elapsed_seconds=1.5,
                 is_streaming=False,
+                model="grok-4-1-fast-reasoning",
             )
         msg = caplog.records[0].message
+        assert "model=grok-4-1-fast-reasoning" in msg
         assert "input=100" in msg
         assert "output=50" in msg
         assert "total=150" in msg
         assert "enrichment_overhead=20" in msg
         assert "mode=sync" in msg
         assert "elapsed=1.50s" in msg
+
+    def test_model_defaults_to_unknown(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="bridge.tokens"):
+            log_token_usage(
+                input_tokens=10,
+                output_tokens=5,
+            )
+        msg = caplog.records[0].message
+        assert "model=unknown" in msg
 
     def test_streaming_mode_label(
         self, caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Summary

Bundle of non-blocking fixes from Kelvin's PR reviews (#26, #28, #30):

- **`.env.example`**: Add 4 missing vars (`IDENTITY_ENABLED`, `LOG_LEVEL`, `DUMP_REQUESTS`, `DUMP_DIR`) with accurate defaults and comments matching actual codebase usage
- **Dead code removal**: Remove `estimate_tokens()` from `bridge/token_logger.py` — defined but never called in any production code path (Kelvin's #28 review, observation 1)
- **Unused variable**: Remove `original_hook = None` in `test_token_integration.py` — assigned but never read (Kelvin's #28 review, observation 2)
- **Model in token log**: Add model name to `log_token_usage()` output — wired from `openai_body["model"]` in both sync and streaming paths (Kelvin's #28 review, observation 4)
- **Manifest schema**: Add `type: manifest` to `structure/manifest.yaml` for consistency with all other YAML files (Kelvin's #30 review, note 4)

## Test plan

- [x] All 484 tests pass (487 baseline - 4 removed `estimate_tokens` tests + 1 new model log test), 8 skipped (live API)
- [x] New test `test_model_defaults_to_unknown` verifies model field in log output
- [x] New test `test_log_contains_all_fields` updated to pass `model=` and assert it appears
- [x] Existing substring assertions (`"input=42"`, `"mode=sync"`, etc.) unaffected by prepended `model=`
- [ ] Kelvin reviews

**Not addressed (by design):**
- `threading.Lock` on StructureLoader — design decision for multi-worker, not a bug
- `_structure_loader` monkey-patch — Phase 2 refactor
- Serve-last-known-good vs fail-fast — consensus was fail-fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)