### PR TITLE
feat: prompt-based tool calling for multi-agent models

### DIFF
--- a/tests/translation/test_prompt_forward.py
+++ b/tests/translation/test_prompt_forward.py
@@ -1,0 +1,206 @@
+"""Tests for prompt-based tool injection in responses_forward.
+
+Tests that multi-agent models get tools serialized into the system prompt
+and the API tools array stripped.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from translation.responses_forward import anthropic_to_responses
+
+
+SAMPLE_TOOLS = [
+    {
+        "name": "Read",
+        "description": "Reads a file.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"file_path": {"type": "string"}},
+            "required": ["file_path"],
+        },
+    },
+    {
+        "name": "Bash",
+        "description": "Runs a command.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    },
+]
+
+
+def _make_request(
+    model: str = "claude-sonnet-4-20250514",
+    tools: list | None = None,
+    messages: list | None = None,
+    system: str = "You are helpful.",
+    stream: bool = False,
+) -> dict:
+    req = {"model": model, "system": system, "stream": stream}
+    if messages is not None:
+        req["messages"] = messages
+    else:
+        req["messages"] = [{"role": "user", "content": "Hello"}]
+    if tools is not None:
+        req["tools"] = tools
+    return req
+
+
+class TestMultiAgentPromptTools:
+    """Tests that multi-agent models use prompt-based tools."""
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_tools_not_in_api_body(self):
+        """Multi-agent requests must NOT have 'tools' in the API body."""
+        request = _make_request(tools=SAMPLE_TOOLS)
+        # Need to reimport to pick up env var for model resolution.
+        result = anthropic_to_responses(request)
+        assert "tools" not in result
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_tools_injected_into_system_prompt(self):
+        """Tool definitions should appear in the system prompt."""
+        request = _make_request(tools=SAMPLE_TOOLS)
+        result = anthropic_to_responses(request)
+        system_msg = result["input"][0]
+        assert system_msg["role"] == "system"
+        assert "### Read" in system_msg["content"]
+        assert "### Bash" in system_msg["content"]
+        assert "<tool_call>" in system_msg["content"]
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_no_tools_no_injection(self):
+        """Without tools, system prompt should not have tool instructions."""
+        request = _make_request(tools=None)
+        result = anthropic_to_responses(request)
+        system_msg = result["input"][0]
+        assert "### Read" not in system_msg["content"]
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_tool_use_in_history_converted_to_text(self):
+        """tool_use blocks in message history should become text."""
+        messages = [
+            {"role": "user", "content": "Read /root/test.py"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me read that."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_abc",
+                        "name": "Read",
+                        "input": {"file_path": "/root/test.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_abc",
+                        "content": "file contents here",
+                    },
+                ],
+            },
+            {"role": "user", "content": "What does it do?"},
+        ]
+        request = _make_request(tools=SAMPLE_TOOLS, messages=messages)
+        result = anthropic_to_responses(request)
+
+        # Find the assistant message that had tool_use -- should be text now.
+        input_msgs = result["input"]
+        # Skip system message.
+        non_system = [m for m in input_msgs if m.get("role") != "system"]
+        assert len(non_system) >= 3
+
+        # The assistant message should contain <tool_call> text.
+        assistant_msg = non_system[1]
+        assert assistant_msg["role"] == "assistant"
+        assert "<tool_call>" in assistant_msg["content"]
+        assert '"Read"' in assistant_msg["content"]
+
+        # The tool result should contain <tool_result> text.
+        tool_result_msg = non_system[2]
+        assert "<tool_result" in tool_result_msg["content"]
+        assert "file contents here" in tool_result_msg["content"]
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_empty_tools_list_no_injection(self):
+        request = _make_request(tools=[])
+        result = anthropic_to_responses(request)
+        assert "tools" not in result
+        system_msg = result["input"][0]
+        assert "Tool Calling" not in system_msg["content"]
+
+
+class TestNonMultiAgentToolsPreserved:
+    """Tests that non-multi-agent models still use API-level tools."""
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4-1-fast-reasoning"})
+    def test_tools_in_api_body(self):
+        """Non-multi-agent models should have tools in the API body."""
+        request = _make_request(tools=SAMPLE_TOOLS)
+        result = anthropic_to_responses(request)
+        assert "tools" in result
+        assert len(result["tools"]) == 2
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4-1-fast-reasoning"})
+    def test_tools_not_in_system_prompt(self):
+        """Non-multi-agent models should NOT have tools in system prompt."""
+        request = _make_request(tools=SAMPLE_TOOLS)
+        result = anthropic_to_responses(request)
+        system_msg = result["input"][0]
+        # Tool names may appear in preamble conventions, but not as ### headers.
+        assert "### Read" not in system_msg["content"]
+
+
+class TestPromptToolsRoundTrip:
+    """End-to-end tests for prompt-based tool calling translation."""
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_system_prompt_preserved(self):
+        """Original system prompt content should be preserved."""
+        request = _make_request(
+            system="You are a coding assistant.", tools=SAMPLE_TOOLS,
+        )
+        result = anthropic_to_responses(request)
+        system_msg = result["input"][0]
+        assert "coding assistant" in system_msg["content"]
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_model_resolved_correctly(self):
+        request = _make_request(tools=SAMPLE_TOOLS)
+        result = anthropic_to_responses(request)
+        assert result["model"] == "grok-4.20-multi-agent"
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_stream_flag_preserved(self):
+        request = _make_request(tools=SAMPLE_TOOLS, stream=True)
+        result = anthropic_to_responses(request)
+        assert result["stream"] is True
+
+    @patch.dict(os.environ, {"GROK_MODEL": "grok-4.20-multi-agent"})
+    def test_thinking_blocks_silently_skipped(self):
+        """Thinking blocks in history should be skipped, not raise errors."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "let me think..."},
+                    {"type": "text", "text": "Hello!"},
+                ],
+            },
+        ]
+        request = _make_request(tools=SAMPLE_TOOLS, messages=messages)
+        result = anthropic_to_responses(request)
+        # Should not raise and should contain the text.
+        non_system = [m for m in result["input"] if m.get("role") != "system"]
+        assistant = non_system[1]
+        assert "Hello!" in assistant["content"]

--- a/tests/translation/test_prompt_reverse.py
+++ b/tests/translation/test_prompt_reverse.py
@@ -1,0 +1,163 @@
+"""Tests for prompt-based tool call parsing in responses_reverse.
+
+Tests that <tool_call> blocks in text responses from multi-agent models
+are properly parsed into Anthropic tool_use content blocks.
+"""
+
+from __future__ import annotations
+
+import json
+
+from translation.responses_reverse import (
+    responses_to_anthropic,
+    translate_responses_response,
+    _build_content,
+    _infer_stop_reason,
+)
+
+
+def _make_response(
+    output: list | None = None,
+    model: str = "grok-4.20-multi-agent",
+    usage: dict | None = None,
+) -> dict:
+    return {
+        "id": "resp_test123",
+        "model": model,
+        "output": output or [],
+        "usage": usage or {"input_tokens": 100, "output_tokens": 50},
+    }
+
+
+def _text_output(text: str) -> dict:
+    """Create a message output item with text."""
+    return {
+        "type": "message",
+        "content": [{"type": "output_text", "text": text}],
+    }
+
+
+class TestBuildContentWithToolCalls:
+    """Tests for _build_content parsing <tool_call> from text."""
+
+    def test_plain_text_unchanged(self):
+        output = [_text_output("Hello, world!")]
+        blocks = _build_content(output)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert blocks[0]["text"] == "Hello, world!"
+
+    def test_single_tool_call_parsed(self):
+        text = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/root/test.py"}}\n</tool_call>'
+        output = [_text_output(text)]
+        blocks = _build_content(output)
+        tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0]["name"] == "Read"
+        assert tool_blocks[0]["input"]["file_path"] == "/root/test.py"
+
+    def test_text_before_tool_call(self):
+        text = 'Let me read that file.\n\n<tool_call>\n{"name": "Read", "parameters": {"file_path": "/test"}}\n</tool_call>'
+        output = [_text_output(text)]
+        blocks = _build_content(output)
+        text_blocks = [b for b in blocks if b["type"] == "text"]
+        tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
+        assert len(text_blocks) >= 1
+        assert "read that file" in text_blocks[0]["text"]
+        assert len(tool_blocks) == 1
+
+    def test_text_after_tool_call(self):
+        text = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/test"}}\n</tool_call>\n\nDone reading.'
+        output = [_text_output(text)]
+        blocks = _build_content(output)
+        text_blocks = [b for b in blocks if b["type"] == "text"]
+        assert any("Done reading" in b["text"] for b in text_blocks)
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/a.py"}}\n</tool_call>\n'
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/b.py"}}\n</tool_call>'
+        )
+        output = [_text_output(text)]
+        blocks = _build_content(output)
+        tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
+        assert len(tool_blocks) == 2
+        assert tool_blocks[0]["input"]["file_path"] == "/a.py"
+        assert tool_blocks[1]["input"]["file_path"] == "/b.py"
+
+    def test_api_native_function_call_still_works(self):
+        """Non-multi-agent function_call items should still work."""
+        output = [{
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "Read",
+            "arguments": '{"file_path": "/test.py"}',
+        }]
+        blocks = _build_content(output)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "tool_use"
+        assert blocks[0]["name"] == "Read"
+
+    def test_malformed_tool_call_kept_as_text(self):
+        """Malformed <tool_call> JSON should result in text only."""
+        text = '<tool_call>\n{not json}\n</tool_call>'
+        output = [_text_output(text)]
+        blocks = _build_content(output)
+        # Malformed is skipped -- we get empty text blocks.
+        tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
+        assert len(tool_blocks) == 0
+
+
+class TestInferStopReason:
+    """Tests for _infer_stop_reason with prompt-based tools."""
+
+    def test_plain_text_end_turn(self):
+        output = [_text_output("Hello")]
+        assert _infer_stop_reason(output) == "end_turn"
+
+    def test_api_function_call_tool_use(self):
+        output = [{"type": "function_call", "call_id": "c1", "name": "Read"}]
+        assert _infer_stop_reason(output) == "tool_use"
+
+    def test_prompt_tool_call_in_text(self):
+        text = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/test"}}\n</tool_call>'
+        output = [_text_output(text)]
+        assert _infer_stop_reason(output) == "tool_use"
+
+    def test_text_without_tool_call(self):
+        output = [_text_output("No tools here")]
+        assert _infer_stop_reason(output) == "end_turn"
+
+
+class TestResponsesToAnthropic:
+    """Full response translation tests."""
+
+    def test_prompt_tool_call_full_response(self):
+        text = (
+            'I will read the file.\n\n'
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/root/main.py"}}\n</tool_call>'
+        )
+        resp = _make_response(output=[_text_output(text)])
+        result = responses_to_anthropic(resp)
+
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["stop_reason"] == "tool_use"
+
+        tool_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0]["name"] == "Read"
+
+    def test_no_tool_call_end_turn(self):
+        resp = _make_response(output=[_text_output("Just text.")])
+        result = responses_to_anthropic(resp)
+        assert result["stop_reason"] == "end_turn"
+        assert all(b["type"] == "text" for b in result["content"])
+
+    def test_error_translation(self):
+        error_resp = {
+            "error": {"type": "invalid_request_error", "message": "Tool not supported"},
+        }
+        result = translate_responses_response(error_resp, status_code=400)
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "invalid_request_error"

--- a/tests/translation/test_prompt_streaming.py
+++ b/tests/translation/test_prompt_streaming.py
@@ -1,0 +1,205 @@
+"""Tests for prompt-based tool call detection in streaming.
+
+Tests that <tool_call> blocks arriving across multiple SSE chunks
+are properly buffered and emitted as tool_use content blocks.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from translation.responses_streaming import ResponsesStreamAdapter
+
+
+async def _lines_from(items: list[str]):
+    """Create an async iterator from a list of SSE lines."""
+    for item in items:
+        yield item
+
+
+def _text_delta(text: str) -> str:
+    """Create an SSE data line for a text delta event."""
+    data = {"type": "response.output_text.delta", "delta": text}
+    return f"data: {json.dumps(data)}"
+
+
+def _completed(
+    output: list | None = None,
+    usage: dict | None = None,
+) -> str:
+    """Create an SSE data line for a response.completed event."""
+    data = {
+        "type": "response.completed",
+        "response": {
+            "status": "completed",
+            "output": output or [],
+            "usage": usage or {"input_tokens": 100, "output_tokens": 50},
+        },
+    }
+    return f"data: {json.dumps(data)}"
+
+
+def _in_progress() -> str:
+    data = {"type": "response.in_progress"}
+    return f"data: {json.dumps(data)}"
+
+
+def _content_part_added() -> str:
+    data = {"type": "response.content_part.added", "part": {"type": "output_text"}}
+    return f"data: {json.dumps(data)}"
+
+
+@pytest.mark.asyncio
+async def test_plain_text_streaming():
+    """Plain text without tool calls streams normally."""
+    lines = [
+        _in_progress(),
+        _content_part_added(),
+        _text_delta("Hello "),
+        _text_delta("world!"),
+        _completed(),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    text_deltas = [e for e in events if e.get("type") == "content_block_delta"
+                   and e.get("delta", {}).get("type") == "text_delta"]
+    assert len(text_deltas) >= 1
+    combined = "".join(d["delta"]["text"] for d in text_deltas)
+    assert "Hello" in combined
+    assert "world!" in combined
+
+    # Stop reason should be end_turn.
+    delta_events = [e for e in events if e.get("type") == "message_delta"]
+    assert delta_events[-1]["delta"]["stop_reason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_in_single_chunk():
+    """A complete <tool_call> in one chunk is parsed into tool_use."""
+    tool_text = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/test.py"}}\n</tool_call>'
+    lines = [
+        _in_progress(),
+        _content_part_added(),
+        _text_delta(tool_text),
+        _completed(),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    tool_starts = [e for e in events if e.get("type") == "content_block_start"
+                   and e.get("content_block", {}).get("type") == "tool_use"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["content_block"]["name"] == "Read"
+
+    # Stop reason should be tool_use.
+    delta_events = [e for e in events if e.get("type") == "message_delta"]
+    assert delta_events[-1]["delta"]["stop_reason"] == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_across_chunks():
+    """A <tool_call> split across multiple text deltas is buffered and parsed."""
+    lines = [
+        _in_progress(),
+        _content_part_added(),
+        _text_delta("<tool_call>\n{"),
+        _text_delta('"name": "Read", '),
+        _text_delta('"parameters": {"file_path": "/test.py"}}'),
+        _text_delta("\n</tool_call>"),
+        _completed(),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    tool_starts = [e for e in events if e.get("type") == "content_block_start"
+                   and e.get("content_block", {}).get("type") == "tool_use"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["content_block"]["name"] == "Read"
+
+
+@pytest.mark.asyncio
+async def test_text_before_tool_call():
+    """Text before a tool call is emitted as text, tool call as tool_use."""
+    lines = [
+        _in_progress(),
+        _content_part_added(),
+        _text_delta("Let me read that.\n\n"),
+        _text_delta('<tool_call>\n{"name": "Read", "parameters": {"file_path": "/test"}}\n</tool_call>'),
+        _completed(),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    text_deltas = [e for e in events if e.get("type") == "content_block_delta"
+                   and e.get("delta", {}).get("type") == "text_delta"]
+    tool_starts = [e for e in events if e.get("type") == "content_block_start"
+                   and e.get("content_block", {}).get("type") == "tool_use"]
+
+    assert len(text_deltas) >= 1
+    assert len(tool_starts) == 1
+    text_combined = "".join(d["delta"]["text"] for d in text_deltas)
+    assert "read that" in text_combined
+
+
+@pytest.mark.asyncio
+async def test_multiple_tool_calls_streaming():
+    """Multiple tool calls in stream are all parsed."""
+    tool1 = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/a.py"}}\n</tool_call>\n'
+    tool2 = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/b.py"}}\n</tool_call>'
+    lines = [
+        _in_progress(),
+        _content_part_added(),
+        _text_delta(tool1),
+        _text_delta(tool2),
+        _completed(),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    tool_starts = [e for e in events if e.get("type") == "content_block_start"
+                   and e.get("content_block", {}).get("type") == "tool_use"]
+    assert len(tool_starts) == 2
+
+
+@pytest.mark.asyncio
+async def test_tool_call_json_deltas():
+    """Tool call parameters are emitted as input_json_delta."""
+    tool_text = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/test.py"}}\n</tool_call>'
+    lines = [
+        _in_progress(),
+        _content_part_added(),
+        _text_delta(tool_text),
+        _completed(),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    json_deltas = [e for e in events if e.get("type") == "content_block_delta"
+                   and e.get("delta", {}).get("type") == "input_json_delta"]
+    assert len(json_deltas) >= 1
+    combined = "".join(d["delta"]["partial_json"] for d in json_deltas)
+    parsed = json.loads(combined)
+    assert parsed["file_path"] == "/test.py"
+
+
+@pytest.mark.asyncio
+async def test_api_native_function_call_still_works():
+    """API-native function_call events still work alongside prompt tools."""
+    lines = [
+        _in_progress(),
+        f'data: {json.dumps({"type": "response.output_item.added", "item": {"type": "function_call", "call_id": "call_1", "name": "Read"}})}',
+        f'data: {json.dumps({"type": "response.function_call_arguments.delta", "delta": "{"})}',
+        f'data: {json.dumps({"type": "response.function_call_arguments.delta", "delta": "\"file_path\": \"/test\"}"})}',
+        f'data: {json.dumps({"type": "response.output_item.done", "item": {"type": "function_call"}})}',
+        _completed(output=[{"type": "function_call"}]),
+    ]
+    adapter = ResponsesStreamAdapter(_lines_from(lines))
+    events = [e async for e in adapter]
+
+    tool_starts = [e for e in events if e.get("type") == "content_block_start"
+                   and e.get("content_block", {}).get("type") == "tool_use"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["content_block"]["name"] == "Read"

--- a/tests/translation/test_prompt_tools.py
+++ b/tests/translation/test_prompt_tools.py
@@ -1,0 +1,186 @@
+"""Tests for prompt-based tool serialization.
+
+Tests the serialization of Anthropic tool definitions into system prompt
+text for multi-agent models that don't support client-side tools.
+"""
+
+from __future__ import annotations
+
+import json
+
+from translation.prompt_tools import (
+    serialize_tools_to_prompt,
+    serialize_tool_results_to_text,
+)
+
+
+# --- Fixtures: sample Anthropic tool definitions ---
+
+SAMPLE_READ_TOOL = {
+    "name": "Read",
+    "description": "Reads a file from the local filesystem.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "file_path": {"type": "string", "description": "Absolute path to the file"},
+            "offset": {"type": "number", "description": "Line number to start from"},
+            "limit": {"type": "number", "description": "Number of lines to read"},
+        },
+        "required": ["file_path"],
+    },
+}
+
+SAMPLE_BASH_TOOL = {
+    "name": "Bash",
+    "description": "Executes a bash command.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "The command to execute"},
+            "timeout": {"type": "number", "description": "Timeout in milliseconds"},
+        },
+        "required": ["command"],
+    },
+}
+
+SAMPLE_EDIT_TOOL = {
+    "name": "Edit",
+    "description": "Performs exact string replacements in files.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "file_path": {"type": "string"},
+            "old_string": {"type": "string"},
+            "new_string": {"type": "string"},
+            "replace_all": {"type": "boolean", "default": False},
+        },
+        "required": ["file_path", "old_string", "new_string"],
+    },
+}
+
+
+class TestSerializeToolsToPrompt:
+    """Tests for serialize_tools_to_prompt."""
+
+    def test_empty_tools_returns_empty(self):
+        result = serialize_tools_to_prompt([])
+        assert result == ""
+
+    def test_single_tool_contains_name(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        assert "### Read" in result
+
+    def test_single_tool_contains_description(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        assert "Reads a file from the local filesystem." in result
+
+    def test_single_tool_contains_schema(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        assert '"file_path"' in result
+        assert '"required"' in result
+
+    def test_multiple_tools_all_present(self):
+        tools = [SAMPLE_READ_TOOL, SAMPLE_BASH_TOOL, SAMPLE_EDIT_TOOL]
+        result = serialize_tools_to_prompt(tools)
+        assert "### Read" in result
+        assert "### Bash" in result
+        assert "### Edit" in result
+
+    def test_contains_tool_call_instructions(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        assert "<tool_call>" in result
+        assert "</tool_call>" in result
+        assert "Tool Calling" in result
+
+    def test_contains_format_example(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        assert '"name":' in result
+        assert '"parameters":' in result
+
+    def test_schema_is_valid_json(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        # Extract the JSON code block for the schema.
+        lines = result.split("\n")
+        in_json = False
+        json_lines = []
+        for line in lines:
+            if line.strip() == "```json":
+                in_json = True
+                continue
+            elif line.strip() == "```" and in_json:
+                break
+            elif in_json:
+                json_lines.append(line)
+        if json_lines:
+            schema = json.loads("\n".join(json_lines))
+            assert schema["type"] == "object"
+            assert "file_path" in schema["properties"]
+
+    def test_tool_without_description(self):
+        tool = {"name": "Minimal", "input_schema": {"type": "object"}}
+        result = serialize_tools_to_prompt([tool])
+        assert "### Minimal" in result
+        assert "No description." in result
+
+    def test_tool_without_schema(self):
+        tool = {"name": "NoSchema", "description": "A tool."}
+        result = serialize_tools_to_prompt([tool])
+        assert "### NoSchema" in result
+        assert "A tool." in result
+
+    def test_multiple_tool_calls_instruction(self):
+        result = serialize_tools_to_prompt([SAMPLE_READ_TOOL])
+        assert "multiple tools" in result.lower() or "multiple <tool_call>" in result.lower()
+
+
+class TestSerializeToolResultsToText:
+    """Tests for serialize_tool_results_to_text."""
+
+    def test_empty_results_returns_empty(self):
+        result = serialize_tool_results_to_text([])
+        assert result == ""
+
+    def test_single_string_result(self):
+        results = [{"tool_use_id": "toolu_abc", "name": "Read", "content": "file contents here"}]
+        result = serialize_tool_results_to_text(results)
+        assert '<tool_result name="Read" id="toolu_abc">' in result
+        assert "file contents here" in result
+        assert "</tool_result>" in result
+
+    def test_result_without_name(self):
+        results = [{"tool_use_id": "toolu_xyz", "content": "output"}]
+        result = serialize_tool_results_to_text(results)
+        assert '<tool_result id="toolu_xyz">' in result
+        assert "output" in result
+
+    def test_nested_content_blocks(self):
+        results = [{
+            "tool_use_id": "toolu_123",
+            "name": "Bash",
+            "content": [
+                {"type": "text", "text": "line 1"},
+                {"type": "text", "text": "line 2"},
+            ],
+        }]
+        result = serialize_tool_results_to_text(results)
+        assert "line 1" in result
+        assert "line 2" in result
+
+    def test_multiple_results(self):
+        results = [
+            {"tool_use_id": "toolu_1", "name": "Read", "content": "content1"},
+            {"tool_use_id": "toolu_2", "name": "Bash", "content": "content2"},
+        ]
+        result = serialize_tool_results_to_text(results)
+        assert "toolu_1" in result
+        assert "toolu_2" in result
+        assert "content1" in result
+        assert "content2" in result
+
+    def test_result_with_string_content_in_list(self):
+        results = [{
+            "tool_use_id": "toolu_str",
+            "content": ["plain string item"],
+        }]
+        result = serialize_tool_results_to_text(results)
+        assert "plain string item" in result

--- a/tests/translation/test_tool_parser.py
+++ b/tests/translation/test_tool_parser.py
@@ -1,0 +1,181 @@
+"""Tests for tool call parsing from model text output.
+
+Tests the extraction of <tool_call> blocks from text and conversion
+to Anthropic tool_use content blocks.
+"""
+
+from __future__ import annotations
+
+import json
+
+from translation.tool_parser import (
+    parse_tool_calls_from_text,
+    has_pending_tool_call,
+)
+
+
+class TestParseToolCallsFromText:
+    """Tests for parse_tool_calls_from_text."""
+
+    def test_no_tool_calls_returns_text(self):
+        text = "Hello, this is a regular response."
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert blocks[0]["text"] == text
+        assert tools == []
+
+    def test_single_tool_call(self):
+        text = '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/root/test.py"}}\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["type"] == "tool_use"
+        assert tools[0]["name"] == "Read"
+        assert tools[0]["input"]["file_path"] == "/root/test.py"
+        assert tools[0]["id"].startswith("toolu_")
+
+    def test_tool_call_with_surrounding_text(self):
+        text = (
+            "Let me read that file.\n\n"
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/root/test.py"}}\n</tool_call>\n\n'
+            "I found the following content."
+        )
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+
+        # Should have text before, tool call, text after.
+        text_blocks = [b for b in blocks if b["type"] == "text"]
+        tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
+        assert len(text_blocks) == 2
+        assert len(tool_blocks) == 1
+        assert "read that file" in text_blocks[0]["text"]
+        assert "found the following" in text_blocks[1]["text"]
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/a.py"}}\n</tool_call>\n'
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/b.py"}}\n</tool_call>'
+        )
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 2
+        assert tools[0]["name"] == "Read"
+        assert tools[0]["input"]["file_path"] == "/a.py"
+        assert tools[1]["input"]["file_path"] == "/b.py"
+        # Each should have a unique ID.
+        assert tools[0]["id"] != tools[1]["id"]
+
+    def test_tool_call_with_nested_json(self):
+        params = {"command": 'echo "hello world"', "timeout": 30000}
+        payload = json.dumps({"name": "Bash", "parameters": params})
+        text = f"<tool_call>\n{payload}\n</tool_call>"
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["input"]["command"] == 'echo "hello world"'
+        assert tools[0]["input"]["timeout"] == 30000
+
+    def test_tool_call_with_complex_nested_params(self):
+        params = {
+            "file_path": "/root/test.py",
+            "old_string": "def foo():\n    pass",
+            "new_string": "def foo():\n    return 42",
+        }
+        payload = json.dumps({"name": "Edit", "parameters": params})
+        text = f"<tool_call>\n{payload}\n</tool_call>"
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["name"] == "Edit"
+        assert "def foo():" in tools[0]["input"]["old_string"]
+
+    def test_empty_parameters(self):
+        text = '<tool_call>\n{"name": "Read", "parameters": {}}\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["input"] == {}
+
+    def test_no_parameters_key(self):
+        text = '<tool_call>\n{"name": "Read"}\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["input"] == {}
+
+    def test_malformed_json_skipped(self):
+        text = '<tool_call>\n{not valid json}\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert tools == []
+        # The malformed block is silently skipped.
+
+    def test_missing_name_skipped(self):
+        text = '<tool_call>\n{"parameters": {"file_path": "/root/test.py"}}\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert tools == []
+
+    def test_non_dict_payload_skipped(self):
+        text = '<tool_call>\n"just a string"\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert tools == []
+
+    def test_mixed_valid_and_invalid(self):
+        text = (
+            '<tool_call>\n{"name": "Read", "parameters": {"file_path": "/a.py"}}\n</tool_call>\n'
+            '<tool_call>\n{bad json}\n</tool_call>\n'
+            '<tool_call>\n{"name": "Bash", "parameters": {"command": "ls"}}\n</tool_call>'
+        )
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 2
+        assert tools[0]["name"] == "Read"
+        assert tools[1]["name"] == "Bash"
+
+    def test_tool_call_single_line(self):
+        text = '<tool_call>{"name": "Read", "parameters": {"file_path": "/test"}}</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["name"] == "Read"
+
+    def test_empty_text_input(self):
+        blocks, tools = parse_tool_calls_from_text("")
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert blocks[0]["text"] == ""
+        assert tools == []
+
+    def test_parameters_not_dict_treated_as_empty(self):
+        text = '<tool_call>\n{"name": "Read", "parameters": "not a dict"}\n</tool_call>'
+        blocks, tools = parse_tool_calls_from_text(text)
+        assert len(tools) == 1
+        assert tools[0]["input"] == {}
+
+    def test_preserves_ordering(self):
+        text = (
+            "First text.\n"
+            '<tool_call>\n{"name": "A", "parameters": {}}\n</tool_call>\n'
+            "Middle text.\n"
+            '<tool_call>\n{"name": "B", "parameters": {}}\n</tool_call>\n'
+            "Last text."
+        )
+        blocks, tools = parse_tool_calls_from_text(text)
+        types = [b["type"] for b in blocks]
+        assert types == ["text", "tool_use", "text", "tool_use", "text"]
+
+
+class TestHasPendingToolCall:
+    """Tests for has_pending_tool_call."""
+
+    def test_no_tags(self):
+        assert not has_pending_tool_call("hello world")
+
+    def test_complete_tag(self):
+        assert not has_pending_tool_call('<tool_call>{"name": "x"}</tool_call>')
+
+    def test_open_tag_only(self):
+        assert has_pending_tool_call('<tool_call>{"name": "')
+
+    def test_multiple_complete(self):
+        text = '<tool_call>a</tool_call><tool_call>b</tool_call>'
+        assert not has_pending_tool_call(text)
+
+    def test_one_complete_one_open(self):
+        text = '<tool_call>a</tool_call><tool_call>b'
+        assert has_pending_tool_call(text)
+
+    def test_empty_string(self):
+        assert not has_pending_tool_call("")

--- a/translation/prompt_tools.py
+++ b/translation/prompt_tools.py
@@ -1,0 +1,134 @@
+"""Prompt-based tool calling for multi-agent models.
+
+Multi-agent models (grok-4.20-multi-agent) do NOT support client-side
+tool definitions via the API. Instead, we serialize tool schemas into the
+system prompt and instruct the model to output structured <tool_call> blocks
+that the bridge parses back into Anthropic tool_use content blocks.
+
+This module handles the serialization half: tools -> prompt text.
+Parsing is in translation/tool_parser.py.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from bridge.logging_config import get_logger
+
+logger = get_logger("prompt_tools")
+
+_TOOL_CALL_INSTRUCTIONS = """\
+
+# Tool Calling
+
+You have access to the tools listed below. To call a tool, output a \
+<tool_call> block with the tool name and parameters as JSON:
+
+```
+<tool_call>
+{"name": "ToolName", "parameters": {"param1": "value1"}}
+</tool_call>
+```
+
+Rules:
+- You may call multiple tools in a single response by using multiple \
+<tool_call> blocks.
+- Parameters MUST be valid JSON matching the tool's parameter schema.
+- Always include required parameters. Omit optional parameters to use defaults.
+- Tool calls can appear anywhere in your response — before, after, or \
+between text.
+- Do NOT wrap <tool_call> blocks in markdown code fences.
+- Do NOT fabricate tools that are not listed below.
+
+## Available Tools
+
+"""
+
+_TOOL_RESULT_HEADER = """\
+The following tool results are from your previous tool calls:
+
+"""
+
+
+def serialize_tools_to_prompt(
+    tools: list[dict[str, Any]],
+) -> str:
+    """Serialize tool definitions into structured prompt text.
+
+    Accepts tools in Anthropic format (name, description, input_schema)
+    and produces a text block suitable for appending to the system prompt.
+
+    Args:
+        tools: List of Anthropic-format tool definitions.
+
+    Returns:
+        A string containing tool descriptions and calling instructions.
+        Returns empty string if no tools provided.
+    """
+    if not tools:
+        return ""
+
+    parts: list[str] = [_TOOL_CALL_INSTRUCTIONS]
+
+    for tool in tools:
+        name = tool.get("name", "unknown")
+        description = tool.get("description", "No description.")
+        schema = tool.get("input_schema", {})
+
+        parts.append(f"### {name}\n")
+        parts.append(f"{description}\n")
+        parts.append(f"Parameters:\n```json\n{json.dumps(schema, indent=2)}\n```\n")
+
+    logger.debug("Serialized %d tools to prompt text", len(tools))
+    return "\n".join(parts)
+
+
+def serialize_tool_results_to_text(
+    tool_results: list[dict[str, Any]],
+) -> str:
+    """Serialize tool results into text for the conversation.
+
+    Converts Anthropic tool_result content blocks into structured text
+    that the model can read as part of the conversation.
+
+    Args:
+        tool_results: List of dicts with keys:
+            - tool_use_id: The ID of the tool call this result is for
+            - name: The tool name (if available)
+            - content: The result content (string or nested blocks)
+
+    Returns:
+        Formatted text representation of tool results.
+    """
+    if not tool_results:
+        return ""
+
+    parts: list[str] = [_TOOL_RESULT_HEADER]
+
+    for result in tool_results:
+        tool_id = result.get("tool_use_id", "unknown")
+        name = result.get("name", "")
+        content = _extract_result_content(result.get("content", ""))
+
+        header = f"<tool_result name=\"{name}\" id=\"{tool_id}\">" if name else f"<tool_result id=\"{tool_id}\">"
+        parts.append(header)
+        parts.append(content)
+        parts.append("</tool_result>\n")
+
+    return "\n".join(parts)
+
+
+def _extract_result_content(raw: str | list[Any] | Any) -> str:
+    """Extract text from tool result content."""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        text_parts: list[str] = []
+        for item in raw:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text_parts.append(item.get("text", ""))
+            elif isinstance(item, str):
+                text_parts.append(item)
+        return "\n".join(text_parts)
+    return str(raw)

--- a/translation/responses_forward.py
+++ b/translation/responses_forward.py
@@ -7,6 +7,11 @@ The Responses API uses a different field layout than Chat Completions:
 - Tool results use type 'function_call_output' with 'call_id'
 - Supports 'previous_response_id' for stateful conversations
 - Supports 'store' (boolean) for server-side persistence
+
+Multi-agent models do NOT support client-side tool definitions. For these
+models, tools are serialized into the system prompt and tool_use/tool_result
+blocks in conversation history are converted to text format. The model
+outputs <tool_call> blocks that the reverse translator parses.
 """
 
 from __future__ import annotations
@@ -16,7 +21,9 @@ from typing import Any
 
 from bridge.logging_config import get_logger
 from translation.config import TranslationConfig, UNSUPPORTED_FEATURES
+from translation.model_routing import detect_endpoint, XAIEndpoint
 from translation.tools import translate_tools as _translate_tools_chat
+from translation.prompt_tools import serialize_tools_to_prompt, serialize_tool_results_to_text
 from enrichment.system_preamble import strip_anthropic_identity
 
 _config = TranslationConfig()
@@ -25,6 +32,10 @@ logger = get_logger("responses_forward")
 
 def anthropic_to_responses(request: dict[str, Any]) -> dict[str, Any]:
     """Translate an Anthropic Messages API request to xAI Responses format.
+
+    For multi-agent models, tools are injected into the system prompt
+    instead of the API tools array. Tool use/result blocks in conversation
+    history are converted to text.
 
     Args:
         request: The incoming Anthropic-format request body.
@@ -42,6 +53,10 @@ def anthropic_to_responses(request: dict[str, Any]) -> dict[str, Any]:
                 f"Disable it in your Claude Code configuration."
             )
 
+    resolved_model = _config.resolve_model(request.get("model", ""))
+    use_prompt_tools = _is_multi_agent_model(resolved_model)
+    anthropic_tools = request.get("tools", []) or []
+
     input_messages: list[dict[str, Any]] = []
 
     # System prompt -> first message with role 'system' in input array.
@@ -53,24 +68,45 @@ def anthropic_to_responses(request: dict[str, Any]) -> dict[str, Any]:
         system = f"{preamble}\n\n{system}"
     elif preamble:
         system = preamble
+
+    # For multi-agent models, append tool definitions to system prompt.
+    if use_prompt_tools and anthropic_tools:
+        tool_prompt = serialize_tools_to_prompt(anthropic_tools)
+        system = f"{system}\n\n{tool_prompt}" if system else tool_prompt
+        logger.info(
+            "Prompt-based tools: injected %d tool definitions into system prompt",
+            len(anthropic_tools),
+        )
+
     if system:
         input_messages.append({"role": "system", "content": system})
 
-    input_messages.extend(_translate_messages(request.get("messages", [])))
+    if use_prompt_tools:
+        input_messages.extend(_translate_messages_prompt_tools(request.get("messages", [])))
+    else:
+        input_messages.extend(_translate_messages(request.get("messages", [])))
 
     result: dict[str, Any] = {
-        "model": _config.resolve_model(request.get("model", "")),
+        "model": resolved_model,
         "input": input_messages,
         "store": False,
         "stream": bool(request.get("stream")),
     }
 
-    # Translate tools to Responses API format.
-    tools = request.get("tools")
-    if tools:
-        result["tools"] = _translate_tools_responses(tools)
+    # Only send tools array for non-multi-agent models.
+    if not use_prompt_tools and anthropic_tools:
+        result["tools"] = _translate_tools_responses(anthropic_tools)
 
     return result
+
+
+def _is_multi_agent_model(resolved_model: str) -> bool:
+    """Check if a model requires prompt-based tool calling.
+
+    Multi-agent models do not accept client-side tool definitions via the
+    API. We detect this from the model name to avoid the 400 error.
+    """
+    return detect_endpoint(resolved_model) == XAIEndpoint.RESPONSES
 
 
 def _flatten_system(system: str | list[dict[str, Any]]) -> str:
@@ -119,6 +155,81 @@ def _translate_tools_responses(
             "parameters": func.get("parameters", {}),
         })
     return responses_tools
+
+
+def _translate_messages_prompt_tools(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Translate messages for prompt-based tool calling.
+
+    Converts tool_use blocks to <tool_call> text format and tool_result
+    blocks to <tool_result> text format. The model sees tools as text in
+    the conversation, not as API-level function calls.
+    """
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        result.extend(_translate_single_message_prompt_tools(msg))
+    return result
+
+
+def _translate_single_message_prompt_tools(
+    msg: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Translate a single message with tool blocks converted to text."""
+    role = msg.get("role", "user")
+    content = msg.get("content")
+
+    if isinstance(content, str):
+        return [{"role": role, "content": content}]
+    if content is None or (isinstance(content, list) and len(content) == 0):
+        return [{"role": role, "content": ""}]
+
+    text_parts: list[str] = []
+
+    for block in content:
+        bt = block.get("type", "")
+        if bt == "text":
+            text_parts.append(block.get("text", ""))
+        elif bt == "tool_use":
+            # Convert tool_use to <tool_call> text format.
+            call_json = json.dumps({
+                "name": block.get("name", ""),
+                "parameters": block.get("input", {}),
+            })
+            text_parts.append(f"<tool_call>\n{call_json}\n</tool_call>")
+        elif bt == "tool_result":
+            # Convert tool_result to <tool_result> text format.
+            raw = block.get("content", "")
+            result_text = _extract_result_text(raw)
+            name = block.get("name", "")
+            tool_id = block.get("tool_use_id", "")
+            header = f'<tool_result name="{name}" id="{tool_id}">' if name else f'<tool_result id="{tool_id}">'
+            text_parts.append(f"{header}\n{result_text}\n</tool_result>")
+        elif bt == "image":
+            raise NotImplementedError(
+                "Image content blocks are not supported by the xAI bridge."
+            )
+        # Skip thinking/redacted_thinking silently.
+        elif bt not in ("thinking", "redacted_thinking"):
+            logger.warning("Unknown content block type in prompt-tools mode: %s", bt)
+
+    combined = "\n\n".join(text_parts) if text_parts else ""
+    return [{"role": role, "content": combined}]
+
+
+def _extract_result_text(raw: str | list[Any] | Any) -> str:
+    """Extract text from a tool result content field."""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        parts: list[str] = []
+        for item in raw:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(item.get("text", ""))
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return str(raw)
 
 
 def _translate_messages(

--- a/translation/responses_reverse.py
+++ b/translation/responses_reverse.py
@@ -5,6 +5,9 @@ The output array contains items with 'type' field:
 - 'message' with content[{type: 'output_text', text: '...'}]
 - 'function_call' with {call_id, name, arguments}
 - 'reasoning' with optional encrypted_content (stripped)
+
+For multi-agent models using prompt-based tools, text responses may
+contain <tool_call> blocks that are parsed into tool_use content blocks.
 """
 
 from __future__ import annotations
@@ -15,6 +18,7 @@ from typing import Any
 
 from bridge.logging_config import get_logger
 from translation.reverse import unescape_text, _ERROR_SUGGESTIONS
+from translation.tool_parser import parse_tool_calls_from_text
 
 logger = get_logger("responses_reverse")
 
@@ -78,24 +82,36 @@ def translate_responses_response(
 
 
 def _build_content(output: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Build Anthropic content blocks from Responses API output array."""
+    """Build Anthropic content blocks from Responses API output array.
+
+    For multi-agent models, text output may contain <tool_call> blocks.
+    These are parsed into proper tool_use content blocks so Claude Code
+    can execute them.
+    """
     content: list[dict[str, Any]] = []
+    has_tool_calls = False
 
     for item in output:
         item_type = item.get("type", "")
 
         if item_type == "message":
-            # Message items contain a content array with output_text blocks.
             for sub in item.get("content", []):
                 sub_type = sub.get("type", "")
                 if sub_type == "output_text":
                     text = sub.get("text", "")
-                    content.append({
-                        "type": "text",
-                        "text": unescape_text(text),
-                    })
+                    text = unescape_text(text)
+                    # Check for prompt-based tool calls in text.
+                    if "<tool_call>" in text:
+                        blocks, tool_calls = parse_tool_calls_from_text(text)
+                        content.extend(blocks)
+                        if tool_calls:
+                            has_tool_calls = True
+                    else:
+                        content.append({"type": "text", "text": text})
 
         elif item_type == "function_call":
+            # API-native tool calls (non-multi-agent models).
+            has_tool_calls = True
             arguments = item.get("arguments", "{}")
             try:
                 args = json.loads(arguments) if isinstance(arguments, str) else arguments
@@ -109,7 +125,6 @@ def _build_content(output: list[dict[str, Any]]) -> list[dict[str, Any]]:
             })
 
         elif item_type == "reasoning":
-            # Reasoning blocks (encrypted or plain) are not passed to Claude Code.
             logger.debug("Skipping reasoning block in Responses output")
             continue
 
@@ -125,12 +140,19 @@ def _build_content(output: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _infer_stop_reason(output: list[dict[str, Any]]) -> str:
     """Infer the Anthropic stop_reason from Responses API output.
 
-    If the output contains function_call items, stop_reason is 'tool_use'.
-    Otherwise, it's 'end_turn'.
+    Checks for both API-native function_call items and prompt-based
+    <tool_call> blocks in text output.
     """
     for item in output:
         if item.get("type") == "function_call":
             return "tool_use"
+        # Check text content for prompt-based tool calls.
+        if item.get("type") == "message":
+            for sub in item.get("content", []):
+                if sub.get("type") == "output_text":
+                    text = sub.get("text", "")
+                    if "<tool_call>" in text and "</tool_call>" in text:
+                        return "tool_use"
     return "end_turn"
 
 

--- a/translation/responses_streaming.py
+++ b/translation/responses_streaming.py
@@ -6,6 +6,10 @@ chat.completion.chunk format used by Chat Completions.
 
 This adapter converts those events to Anthropic's streaming protocol:
 message_start, content_block_start/delta/stop, message_delta, message_stop.
+
+For multi-agent models using prompt-based tools, text deltas are buffered
+when a <tool_call> tag is detected. The buffer is flushed as a tool_use
+block when </tool_call> is found.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from typing import Any, AsyncIterator
 
 from translation.config import STOP_REASON_MAP
 from translation.reverse import unescape_text
+from translation.tool_parser import parse_tool_calls_from_text, has_pending_tool_call
 
 
 def _msg_start(model: str = "grok-4.20-multi-agent") -> dict[str, Any]:
@@ -56,8 +61,8 @@ def _close(
 class ResponsesStreamAdapter:
     """Async adapter: xAI Responses API SSE events -> Anthropic events.
 
-    Handles the semantic event types from the Responses API streaming
-    format and translates them to Anthropic's flat event stream.
+    Handles both API-native function calls and prompt-based tool calls
+    (detected via <tool_call> tags in text output).
     """
 
     def __init__(self, source: AsyncIterator[str]) -> None:
@@ -70,6 +75,10 @@ class ResponsesStreamAdapter:
         self._model = "grok-4.20-multi-agent"
         self._q: list[dict[str, Any]] = []
         self.usage: dict[str, int] = {}
+        # Buffer for prompt-based tool call detection in streaming.
+        self._text_buffer = ""
+        self._buffering = False
+        self._found_tool_calls = False
 
     def __aiter__(self) -> ResponsesStreamAdapter:
         return self
@@ -97,11 +106,7 @@ class ResponsesStreamAdapter:
                 if not line.strip():
                     continue
 
-                # Parse SSE: "event: <type>\ndata: <json>"
-                # Lines may come as "event: response.output_text.delta"
-                # followed by "data: {...}" or as just "data: {...}".
                 if line.startswith("event:"):
-                    # Event type line; the data line follows.
                     continue
                 if not line.startswith("data:"):
                     continue
@@ -149,18 +154,13 @@ class ResponsesStreamAdapter:
             if not self._started:
                 self._started = True
                 events.append(_msg_start(self._model))
-            if not self._text_block_open:
-                events.extend(self._open_text_block())
             text = data.get("delta", "")
             if text:
-                events.append({
-                    "type": "content_block_delta",
-                    "index": self._block_index,
-                    "delta": {"type": "text_delta", "text": unescape_text(text)},
-                })
+                events.extend(self._handle_text_delta(text))
 
         elif event_type == "response.output_text.done":
-            pass  # Text finalization; we already streamed deltas.
+            # Text finalization -- flush any remaining buffer.
+            events.extend(self._flush_text_buffer())
 
         elif event_type == "response.function_call_arguments.delta":
             if not self._started:
@@ -175,7 +175,7 @@ class ResponsesStreamAdapter:
                 })
 
         elif event_type == "response.function_call_arguments.done":
-            pass  # Full arguments; we already streamed deltas.
+            pass
 
         elif event_type == "response.output_item.done":
             events.extend(self._close_current_block())
@@ -186,24 +186,29 @@ class ResponsesStreamAdapter:
                 events.extend(self._open_text_block())
 
         elif event_type == "response.content_part.done":
-            pass  # Part finalized; block close handled by output_item.done.
+            pass
 
         elif event_type == "response.completed":
             response = data.get("response", {})
             usage = response.get("usage", {})
             self.usage = usage
+            events.extend(self._flush_text_buffer())
             events.extend(self._close_current_block())
             stop = self._infer_stop(response)
+            if self._found_tool_calls:
+                stop = "tool_use"
             events.extend(_close(stop, usage))
             self._done = True
 
         elif event_type == "response.incomplete":
+            events.extend(self._flush_text_buffer())
             events.extend(self._close_current_block())
             events.extend(_close("max_tokens"))
             self._done = True
 
         elif event_type == "response.failed":
             error = data.get("response", {}).get("error", {})
+            events.extend(self._flush_text_buffer())
             events.extend(self._close_current_block())
             events.append({
                 "type": "error",
@@ -214,7 +219,105 @@ class ResponsesStreamAdapter:
             })
             self._done = True
 
-        # Ignore reasoning events and unknown types silently.
+        return events
+
+    def _handle_text_delta(self, text: str) -> list[dict[str, Any]]:
+        """Handle a text delta, buffering when tool calls are detected.
+
+        Detects <tool_call> tags and buffers text until </tool_call> is
+        found, then emits proper tool_use blocks.
+        """
+        self._text_buffer += text
+        events: list[dict[str, Any]] = []
+
+        # Check if we have any completed tool call blocks to parse.
+        while "<tool_call>" in self._text_buffer and "</tool_call>" in self._text_buffer:
+            events.extend(self._parse_buffered_tool_calls())
+
+        # If we are in the middle of a tool call, keep buffering.
+        if has_pending_tool_call(self._text_buffer):
+            self._buffering = True
+            return events
+
+        # No pending tool call -- flush plain text.
+        if self._text_buffer and not self._buffering:
+            if not self._text_block_open:
+                events.extend(self._open_text_block())
+            events.append({
+                "type": "content_block_delta",
+                "index": self._block_index,
+                "delta": {"type": "text_delta", "text": unescape_text(self._text_buffer)},
+            })
+            self._text_buffer = ""
+
+        self._buffering = False
+        return events
+
+    def _parse_buffered_tool_calls(self) -> list[dict[str, Any]]:
+        """Parse completed <tool_call> blocks from the buffer.
+
+        Emits text before the tool call, then the tool_use block itself.
+        Updates the buffer to contain only remaining unparsed text.
+        """
+        events: list[dict[str, Any]] = []
+        content_blocks, tool_calls = parse_tool_calls_from_text(self._text_buffer)
+
+        for block in content_blocks:
+            if block["type"] == "text":
+                text = block.get("text", "")
+                if text:
+                    if not self._text_block_open:
+                        events.extend(self._open_text_block())
+                    events.append({
+                        "type": "content_block_delta",
+                        "index": self._block_index,
+                        "delta": {"type": "text_delta", "text": unescape_text(text)},
+                    })
+                    # Close text block before tool block.
+                    events.extend(self._close_current_block())
+            elif block["type"] == "tool_use":
+                self._found_tool_calls = True
+                events.extend(self._close_current_block())
+                self._tool_block_open = True
+                events.append({
+                    "type": "content_block_start",
+                    "index": self._block_index,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": block["id"],
+                        "name": block["name"],
+                        "input": {},
+                    },
+                })
+                # Send the full input as a single JSON delta.
+                input_json = json.dumps(block.get("input", {}))
+                events.append({
+                    "type": "content_block_delta",
+                    "index": self._block_index,
+                    "delta": {"type": "input_json_delta", "partial_json": input_json},
+                })
+                events.extend(self._close_current_block())
+
+        self._text_buffer = ""
+        return events
+
+    def _flush_text_buffer(self) -> list[dict[str, Any]]:
+        """Flush remaining text buffer as text content."""
+        if not self._text_buffer:
+            return []
+        events: list[dict[str, Any]] = []
+        # If there are tool calls in remaining buffer, parse them.
+        if "<tool_call>" in self._text_buffer:
+            events.extend(self._parse_buffered_tool_calls())
+        elif self._text_buffer.strip():
+            if not self._text_block_open:
+                events.extend(self._open_text_block())
+            events.append({
+                "type": "content_block_delta",
+                "index": self._block_index,
+                "delta": {"type": "text_delta", "text": unescape_text(self._text_buffer)},
+            })
+        self._text_buffer = ""
         return events
 
     def _open_text_block(self) -> list[dict[str, Any]]:
@@ -265,8 +368,10 @@ class ResponsesStreamAdapter:
         if not self._started:
             events.append(_msg_start(self._model))
             self._started = True
+        events.extend(self._flush_text_buffer())
         events.extend(self._close_current_block())
-        events.extend(_close("end_turn"))
+        stop = "tool_use" if self._found_tool_calls else "end_turn"
+        events.extend(_close(stop))
         self._done = True
         return events
 

--- a/translation/tool_parser.py
+++ b/translation/tool_parser.py
@@ -1,0 +1,136 @@
+"""Parse tool calls from model text output.
+
+When multi-agent models receive tools via the system prompt (not the API),
+they output tool calls as structured <tool_call> blocks in their text
+response. This module extracts those blocks and converts them to Anthropic
+tool_use content blocks.
+
+Paired with translation/prompt_tools.py which handles serialization.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any
+
+from bridge.logging_config import get_logger
+
+logger = get_logger("tool_parser")
+
+# Regex to match <tool_call>...</tool_call> blocks.
+# Uses DOTALL so the JSON payload can span multiple lines.
+_TOOL_CALL_PATTERN = re.compile(
+    r"<tool_call>\s*(.*?)\s*</tool_call>",
+    re.DOTALL,
+)
+
+
+def parse_tool_calls_from_text(
+    text: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Parse <tool_call> blocks from model text output.
+
+    Extracts tool calls and returns them as Anthropic tool_use content
+    blocks. Text surrounding tool calls is returned as text content blocks.
+
+    Args:
+        text: The full text output from the model, possibly containing
+            one or more <tool_call> blocks.
+
+    Returns:
+        A tuple of (content_blocks, tool_calls_only) where:
+        - content_blocks: Ordered list of text and tool_use blocks
+        - tool_calls_only: Just the tool_use blocks (for stop_reason)
+    """
+    if "<tool_call>" not in text:
+        return [{"type": "text", "text": text}], []
+
+    content: list[dict[str, Any]] = []
+    tool_calls: list[dict[str, Any]] = []
+    last_end = 0
+
+    for match in _TOOL_CALL_PATTERN.finditer(text):
+        # Add preceding text as a text block.
+        preceding = text[last_end:match.start()].strip()
+        if preceding:
+            content.append({"type": "text", "text": preceding})
+
+        # Parse the JSON payload.
+        raw_json = match.group(1)
+        tool_block = _parse_single_tool_call(raw_json)
+        if tool_block is not None:
+            content.append(tool_block)
+            tool_calls.append(tool_block)
+
+        last_end = match.end()
+
+    # Add trailing text after the last tool call.
+    trailing = text[last_end:].strip()
+    if trailing:
+        content.append({"type": "text", "text": trailing})
+
+    if not content:
+        content.append({"type": "text", "text": ""})
+
+    logger.debug(
+        "Parsed %d tool calls from text (%d total content blocks)",
+        len(tool_calls), len(content),
+    )
+    return content, tool_calls
+
+
+def _parse_single_tool_call(raw_json: str) -> dict[str, Any] | None:
+    """Parse a single tool call JSON payload into a tool_use block.
+
+    Args:
+        raw_json: The JSON string inside a <tool_call> block.
+
+    Returns:
+        An Anthropic tool_use content block, or None if parsing fails.
+    """
+    try:
+        data = json.loads(raw_json)
+    except json.JSONDecodeError as e:
+        logger.warning("Malformed tool call JSON: %s (error: %s)", raw_json[:200], e)
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("Tool call payload is not a dict: %s", type(data).__name__)
+        return None
+
+    name = data.get("name")
+    if not name:
+        logger.warning("Tool call missing 'name' field: %s", raw_json[:200])
+        return None
+
+    parameters = data.get("parameters", {})
+    if not isinstance(parameters, dict):
+        logger.warning("Tool call parameters is not a dict for %s", name)
+        parameters = {}
+
+    tool_id = f"toolu_{uuid.uuid4().hex[:24]}"
+    return {
+        "type": "tool_use",
+        "id": tool_id,
+        "name": name,
+        "input": parameters,
+    }
+
+
+def has_pending_tool_call(buffer: str) -> bool:
+    """Check if a text buffer has an unclosed <tool_call> tag.
+
+    Used by streaming to determine if we should keep buffering.
+
+    Args:
+        buffer: Accumulated text from streaming chunks.
+
+    Returns:
+        True if there is an opening <tool_call> without a matching
+        </tool_call>.
+    """
+    opens = buffer.count("<tool_call>")
+    closes = buffer.count("</tool_call>")
+    return opens > closes


### PR DESCRIPTION
## Summary

Multi-agent models (e.g., `grok-4.20-multi-agent`) reject client-side tool definitions (`400: "Client side tool is not supported"`). This PR implements prompt-based tool calling: tool definitions are serialized into the system prompt, the model outputs `<tool_call>` XML blocks, and the bridge parses them back into Anthropic `tool_use` content blocks.

## What's New

**New modules:**
- `translation/prompt_tools.py` (134 lines) — tool definition serializer + result serializer
- `translation/tool_parser.py` (136 lines) — `<tool_call>` block parser with mixed content support

**Modified:**
- `translation/responses_forward.py` — strip tools array, inject into system prompt, convert tool_use/tool_result history to text
- `translation/responses_reverse.py` — parse `<tool_call>` blocks from text output into `tool_use` content blocks
- `translation/responses_streaming.py` — buffer text during `<tool_call>` blocks, emit as `tool_use` events

**Tests:** 71 new tests across 5 test files (prompt_tools, tool_parser, prompt_forward, prompt_reverse, prompt_streaming)

## Design

- XML delimiters (`<tool_call>`/`</tool_call>`) for reliable parsing
- Enrichment pipeline still runs — tools enriched at Anthropic level before serialization
- Streaming uses tag-count buffering (`opens > closes`) for incomplete tool calls
- Conversation history with tool_use/tool_result converted to matching text format
- Non-multi-agent models completely unaffected (original code path preserved)

## Test Results

680 tests pass (609 existing + 71 new), zero failures.

Extends #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)