### PR TITLE
Fix subagent task lifecycle closure

### DIFF
--- a/enrichment/behavioral/tool_knowledge.py
+++ b/enrichment/behavioral/tool_knowledge.py
@@ -312,18 +312,24 @@ TOOL_KNOWLEDGE: dict[str, dict[str, Any]] = {
         "what": (
             "Launches a REAL SUBAGENT that autonomously performs work. The subagent "
             "reads files, makes API calls, writes code, and posts comments. Use "
-            "run_in_background: true for non-blocking execution."
+            "run_in_background: true for non-blocking execution. After completing "
+            "all work, the subagent MUST call TaskUpdate to mark any associated "
+            "tracking entry as completed with status: 'completed' and a summary of "
+            "what was done."
         ),
         "why": {
             "problem_context": (
                 "This is the execution tool — the only way to delegate actual work "
                 "to a subagent. Unlike TaskCreate (which only creates a tracking entry), "
-                "the Task tool starts an autonomous agent that performs real operations."
+                "the Task tool starts an autonomous agent that performs real operations. "
+                "The full lifecycle is: TaskCreate (plan) -> Task (execute) -> TaskUpdate "
+                "(mark completed). A task left without TaskUpdate pollutes the task list."
             ),
             "failure_modes": [
                 "Using TaskCreate instead of Task — TaskCreate only creates a tracking entry, no work happens",
                 "Vague prompts produce vague results — always include scope, context, acceptance criteria, and constraints",
                 "Forgetting run_in_background: true causes the orchestrator to block until the subagent finishes",
+                "Completing work without calling TaskUpdate — leaves orphaned pending tasks that require manual cleanup",
             ],
         },
         "when": {
@@ -335,22 +341,28 @@ TOOL_KNOWLEDGE: dict[str, dict[str, Any]] = {
                 "context (file paths, prior decisions), acceptance criteria (how to "
                 "verify completion), constraints (boundaries, what NOT to do), and "
                 "reminders (skills to read, conventions to follow). Launch independent "
-                "tasks in parallel with run_in_background: true."
+                "tasks in parallel with run_in_background: true. Before finishing, "
+                "ALWAYS call TaskUpdate with status: 'completed' and include evidence "
+                "of what was accomplished."
             ),
         },
     },
     "TaskUpdate": {
         "what": (
             "Updates the status or metadata of an existing tracking entry. Does not "
-            "perform any work. Does not launch a subagent."
+            "perform any work. Does not launch a subagent. MUST be called by subagents "
+            "after completing their delegated work to mark the task as completed."
         ),
         "why": {
             "problem_context": (
                 "Tracking management — mark tasks as complete, update status, or "
-                "add notes. This is bookkeeping, not execution."
+                "add notes. This is bookkeeping, not execution. Every subagent that "
+                "receives a task_id in its delegation prompt must call TaskUpdate "
+                "with status: 'completed' before finishing."
             ),
             "failure_modes": [
                 "Expecting TaskUpdate to trigger work — it only updates the tracking record",
+                "Subagent finishes work without calling TaskUpdate — leaves orphaned pending tasks in the task list",
             ],
         },
         "when": {
@@ -358,8 +370,9 @@ TOOL_KNOWLEDGE: dict[str, dict[str, Any]] = {
             "use_before": [],
             "use_instead_of": [],
             "sequencing": (
-                "Use after a Task subagent completes to record the outcome. "
-                "Or use to update status during long-running work."
+                "MUST be called at the end of every subagent's work to close the "
+                "task lifecycle. Include a summary of what was done and any evidence "
+                "of completion (test results, file paths modified, etc.)."
             ),
         },
     },

--- a/enrichment/system_preamble.py
+++ b/enrichment/system_preamble.py
@@ -163,6 +163,12 @@ Critical distinction: planning tools and execution tools are SEPARATE steps.
 1. TaskCreate to plan and track (optional, for organization)
 2. Task tool to execute (required, for actual work)
 3. Planning is NOT doing. Creating a tracking entry does NOT launch work.
+4. After completing work, ALWAYS call TaskUpdate with status: 'completed' \
+and a summary of what was done. A task is NOT complete until TaskUpdate closes it.
+
+**Task lifecycle closure is mandatory.** Subagents that finish work without \
+calling TaskUpdate leave orphaned entries that pollute the task list and \
+force manual cleanup. Every subagent must close its own tasks.
 
 A vague delegation ("review this") produces vague results. \
 A structured delegation with scope, context, and criteria produces focused, \

--- a/structure/behavioral/what.yaml
+++ b/structure/behavioral/what.yaml
@@ -59,11 +59,15 @@ tools:
   Task: >
     Launches a REAL SUBAGENT that autonomously performs work. The subagent
     reads files, makes API calls, writes code, and posts comments. Use
-    run_in_background: true for non-blocking execution.
+    run_in_background: true for non-blocking execution. After completing
+    all work, the subagent MUST call TaskUpdate to mark any associated
+    tracking entry as completed with status 'completed' and a summary.
 
   TaskUpdate: >
     Updates the status or metadata of an existing tracking entry. Does not
-    perform any work. Does not launch a subagent.
+    perform any work. Does not launch a subagent. MUST be called by
+    subagents after completing their delegated work to close the task
+    lifecycle.
 
   TaskGet: >
     Reads a single tracking entry by ID. Returns task metadata, status,

--- a/structure/behavioral/when.yaml
+++ b/structure/behavioral/when.yaml
@@ -132,7 +132,9 @@ tools:
       context (file paths, prior decisions), acceptance criteria (how to
       verify completion), constraints (boundaries, what NOT to do), and
       reminders (skills to read, conventions to follow). Launch independent
-      tasks in parallel with run_in_background: true.
+      tasks in parallel with run_in_background: true. Before finishing,
+      ALWAYS call TaskUpdate with status completed and include evidence
+      of what was accomplished.
 
   TaskUpdate:
     prerequisites:
@@ -140,8 +142,9 @@ tools:
     use_before: []
     use_instead_of: []
     sequencing: >
-      Use after a Task subagent completes to record the outcome.
-      Or use to update status during long-running work.
+      MUST be called at the end of every subagent work session to close
+      the task lifecycle. Include a summary of what was done and any
+      evidence of completion (test results, file paths modified, etc.).
 
   TaskGet:
     prerequisites:

--- a/structure/behavioral/why.yaml
+++ b/structure/behavioral/why.yaml
@@ -109,17 +109,24 @@ tools:
       This is the execution tool — the only way to delegate actual work
       to a subagent. Unlike TaskCreate (which only creates a tracking entry),
       the Task tool starts an autonomous agent that performs real operations.
+      The full lifecycle is TaskCreate (plan) then Task (execute) then
+      TaskUpdate (mark completed). A task left without TaskUpdate pollutes
+      the task list.
     failure_modes:
       - Using TaskCreate instead of Task — TaskCreate only creates a tracking entry, no work happens
       - Vague prompts produce vague results — always include scope, context, acceptance criteria, and constraints
       - "Forgetting run_in_background: true causes the orchestrator to block until the subagent finishes"
+      - Completing work without calling TaskUpdate — leaves orphaned pending tasks that require manual cleanup
 
   TaskUpdate:
     problem_context: >
       Tracking management — mark tasks as complete, update status, or
-      add notes. This is bookkeeping, not execution.
+      add notes. This is bookkeeping, not execution. Every subagent that
+      receives a task_id must call TaskUpdate with status completed
+      before finishing.
     failure_modes:
       - Expecting TaskUpdate to trigger work — it only updates the tracking record
+      - Subagent finishes work without calling TaskUpdate — leaves orphaned pending tasks in the task list
 
   TaskGet:
     problem_context: >


### PR DESCRIPTION
## Summary

Fixes #44 — Subagents complete work but leave TaskCreate entries open because the enrichment layer and system preamble never instruct them to call TaskUpdate upon completion.

**Changes across three enrichment surfaces:**

- **`enrichment/behavioral/tool_knowledge.py`**: Enhanced Task WHAT to include "subagent MUST call TaskUpdate", added failure mode for orphaned tasks, updated sequencing to mandate closure. Enhanced TaskUpdate WHAT/WHY/WHEN to emphasize mandatory closure by subagents.
- **`structure/behavioral/what.yaml`**, **`why.yaml`**, **`when.yaml`**: Matching YAML definitions updated with lifecycle closure instructions.
- **`enrichment/system_preamble.py`**: Added Step 4 to the orchestration workflow ("After completing work, ALWAYS call TaskUpdate") and a mandatory closure paragraph.

**What this does NOT change (orchestrator-side):**
- Delegation templates in `orchestrator_task-decomposition/SKILL.md` — those live in the orchestrator's repo, not the bridge. The issue mentions updating them too; that should be done separately in the orchestrator's skill files.
- `delegation-standards.md` — same, orchestrator-side.

## Test plan

- [x] All 641 tests pass (0 failures, 0 errors)
- [x] YAML files parse correctly (verified with `yaml.safe_load`)
- [x] No YAML colon-in-string gotcha (all failure_modes entries verified as strings)
- [x] No regression on existing TaskCreate/Task distinction from #34
- [ ] Verify with a real delegation: TaskCreate + Task execution produces automatic TaskUpdate closure

Generated with [Claude Code](https://claude.com/claude-code)