### PR TITLE
fix: Fold enrichment metadata into tool descriptions

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,7 +101,11 @@ class TestEnrichmentIntegration:
         assert tools == original
 
     def test_translation_after_enrichment_preserves_core_fields(self):
-        """Core fields (name, description, parameters) survive enrichment + translation."""
+        """Core fields (name, description, parameters) survive enrichment + translation.
+
+        The description now includes folded enrichment metadata appended
+        after the original description text (fix for Issue #35).
+        """
         enricher = create_enricher(mode="full")
         set_tool_enrichment_hook(enricher.enrich)
 
@@ -112,7 +116,11 @@ class TestEnrichmentIntegration:
 
         func = result[0]["function"]
         assert func["name"] == "Bash"
-        assert func["description"] == "Executes commands"
+        # Original description is preserved at the start, with enrichment
+        # metadata appended after it (Issue #35 fix).
+        assert func["description"].startswith("Executes commands")
+        # Enrichment data is now folded into the description
+        assert len(func["description"]) > len("Executes commands")
         assert func["parameters"]["required"] == ["command"]
 
     def test_multiple_tools_all_enriched(self):

--- a/tests/translation/test_enrichment_folding.py
+++ b/tests/translation/test_enrichment_folding.py
@@ -1,0 +1,291 @@
+"""Tests for enrichment metadata folding into tool descriptions.
+
+Verifies that enrichment fields added by the engine (behavioral_what,
+behavioral_why, behavioral_when, _links, _error_format, _near_miss,
+_quality, _anti_patterns, outputSchema) are serialized into the
+description field so the guest model receives them via the OpenAI format.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from translation.enrichment_folding import (
+    fold_enrichment_into_description,
+    _remove_remaining_enrichment_fields,
+)
+
+
+def _make_tool(
+    name: str = "Read",
+    description: str = "Reads a file.",
+    **extra: Any,
+) -> dict[str, Any]:
+    """Create a minimal tool dict with optional enrichment fields."""
+    tool: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "input_schema": {"type": "object", "properties": {}},
+    }
+    tool.update(extra)
+    return tool
+
+
+class TestBehavioralWhat:
+    """behavioral_what is folded into description."""
+
+    def test_what_appended_to_description(self) -> None:
+        tool = _make_tool(behavioral_what="Enhanced: reads files from disk.")
+        fold_enrichment_into_description([tool])
+        assert "Enhanced: reads files from disk." in tool["description"]
+        assert "[Enhanced Description]" in tool["description"]
+
+    def test_original_description_preserved(self) -> None:
+        tool = _make_tool(behavioral_what="Enhanced version.")
+        fold_enrichment_into_description([tool])
+        assert tool["description"].startswith("Reads a file.")
+
+    def test_what_field_removed_after_folding(self) -> None:
+        tool = _make_tool(behavioral_what="Enhanced version.")
+        fold_enrichment_into_description([tool])
+        assert "behavioral_what" not in tool
+
+
+class TestBehavioralWhy:
+    """behavioral_why is folded into description."""
+
+    def test_why_dict_folded(self) -> None:
+        why = {
+            "problem_context": "Need to inspect file contents.",
+            "failure_modes": ["File not found", "Permission denied"],
+        }
+        tool = _make_tool(behavioral_why=why)
+        fold_enrichment_into_description([tool])
+        assert "[Why Use This Tool]" in tool["description"]
+        assert "Need to inspect file contents." in tool["description"]
+        assert "File not found" in tool["description"]
+        assert "Permission denied" in tool["description"]
+
+    def test_why_string_folded(self) -> None:
+        tool = _make_tool(behavioral_why="Use when you need file content.")
+        fold_enrichment_into_description([tool])
+        assert "Use when you need file content." in tool["description"]
+
+    def test_why_field_removed(self) -> None:
+        tool = _make_tool(behavioral_why={"problem_context": "test"})
+        fold_enrichment_into_description([tool])
+        assert "behavioral_why" not in tool
+
+
+class TestBehavioralWhen:
+    """behavioral_when is folded into description."""
+
+    def test_when_prerequisites_folded(self) -> None:
+        when = {"prerequisites": ["Read"], "use_before": ["Edit"]}
+        tool = _make_tool(behavioral_when=when)
+        fold_enrichment_into_description([tool])
+        assert "[When To Use]" in tool["description"]
+        assert "Prerequisites: Read" in tool["description"]
+        assert "Use before: Edit" in tool["description"]
+
+    def test_when_do_not_use_for(self) -> None:
+        when = {"do_not_use_for": ["finding files", "searching content"]}
+        tool = _make_tool(behavioral_when=when)
+        fold_enrichment_into_description([tool])
+        assert "Do NOT use for: finding files" in tool["description"]
+        assert "Do NOT use for: searching content" in tool["description"]
+
+    def test_when_sequencing(self) -> None:
+        when = {"sequencing": "Always Read before Edit."}
+        tool = _make_tool(behavioral_when=when)
+        fold_enrichment_into_description([tool])
+        assert "Sequencing: Always Read before Edit." in tool["description"]
+
+    def test_when_field_removed(self) -> None:
+        tool = _make_tool(behavioral_when={"prerequisites": ["Read"]})
+        fold_enrichment_into_description([tool])
+        assert "behavioral_when" not in tool
+
+
+class TestLinks:
+    """_links (HATEOAS) is folded into description."""
+
+    def test_links_related_folded(self) -> None:
+        links = {"related": ["Edit", "Write"]}
+        tool = _make_tool(_links=links)
+        fold_enrichment_into_description([tool])
+        assert "[Navigation]" in tool["description"]
+        assert "Related tools: Edit, Write" in tool["description"]
+
+    def test_links_on_error_folded(self) -> None:
+        links = {"on_error": {"file_not_found": "Use Glob first."}}
+        tool = _make_tool(_links=links)
+        fold_enrichment_into_description([tool])
+        assert "On file_not_found: Use Glob first." in tool["description"]
+
+    def test_links_field_removed(self) -> None:
+        tool = _make_tool(_links={"related": ["Edit"]})
+        fold_enrichment_into_description([tool])
+        assert "_links" not in tool
+
+
+class TestErrorFormat:
+    """_error_format is folded into description."""
+
+    def test_error_format_folded(self) -> None:
+        error_fmt = {
+            "errors": [
+                {"error": "File not found", "suggestion": "Use Glob"},
+            ],
+            "format": {"error": "string", "suggestion": "string"},
+        }
+        tool = _make_tool(_error_format=error_fmt)
+        fold_enrichment_into_description([tool])
+        assert "[Error Handling]" in tool["description"]
+        assert "File not found: Use Glob" in tool["description"]
+
+    def test_error_format_field_removed(self) -> None:
+        tool = _make_tool(_error_format={"errors": []})
+        fold_enrichment_into_description([tool])
+        assert "_error_format" not in tool
+
+
+class TestNearMiss:
+    """_near_miss is folded into description."""
+
+    def test_near_miss_aliases_folded(self) -> None:
+        near_miss = {"aliases": ["cat", "view"], "commonly_confused_with": ["Bash cat"]}
+        tool = _make_tool(_near_miss=near_miss)
+        fold_enrichment_into_description([tool])
+        assert "[Aliases]" in tool["description"]
+        assert "Also known as: cat, view" in tool["description"]
+        assert "Commonly confused with: Bash cat" in tool["description"]
+
+    def test_near_miss_field_removed(self) -> None:
+        tool = _make_tool(_near_miss={"aliases": ["cat"]})
+        fold_enrichment_into_description([tool])
+        assert "_near_miss" not in tool
+
+
+class TestAntiPatterns:
+    """_anti_patterns is folded into description."""
+
+    def test_anti_patterns_folded(self) -> None:
+        anti = [
+            {
+                "anti_pattern": "Using Bash for file reads",
+                "why_bad": "Loses tool tracking.",
+                "do_instead": "Use Read tool.",
+            }
+        ]
+        tool = _make_tool(_anti_patterns=anti)
+        fold_enrichment_into_description([tool])
+        assert "[Anti-Patterns]" in tool["description"]
+        assert "AVOID: Using Bash for file reads" in tool["description"]
+        assert "Why: Loses tool tracking." in tool["description"]
+        assert "Instead: Use Read tool." in tool["description"]
+
+    def test_anti_patterns_field_removed(self) -> None:
+        tool = _make_tool(_anti_patterns=[{"anti_pattern": "test"}])
+        fold_enrichment_into_description([tool])
+        assert "_anti_patterns" not in tool
+
+
+class TestOutputSchema:
+    """outputSchema is folded into description."""
+
+    def test_output_schema_folded(self) -> None:
+        schema = {"type": "object", "properties": {"content": {"type": "string"}}}
+        tool = _make_tool(outputSchema=schema)
+        fold_enrichment_into_description([tool])
+        assert "[Output Schema]" in tool["description"]
+        assert '"content"' in tool["description"]
+
+    def test_output_schema_field_removed(self) -> None:
+        tool = _make_tool(outputSchema={"type": "string"})
+        fold_enrichment_into_description([tool])
+        assert "outputSchema" not in tool
+
+
+class TestQuality:
+    """_quality is folded into description."""
+
+    def test_quality_folded(self) -> None:
+        quality = {"gate": "required", "threshold": "95%"}
+        tool = _make_tool(_quality=quality)
+        fold_enrichment_into_description([tool])
+        assert "[Quality]" in tool["description"]
+        assert "gate: required" in tool["description"]
+
+    def test_quality_field_removed(self) -> None:
+        tool = _make_tool(_quality={"gate": "required"})
+        fold_enrichment_into_description([tool])
+        assert "_quality" not in tool
+
+
+class TestEdgeCases:
+    """Edge cases and integration scenarios."""
+
+    def test_no_enrichment_fields_description_unchanged(self) -> None:
+        tool = _make_tool()
+        original_desc = tool["description"]
+        fold_enrichment_into_description([tool])
+        assert tool["description"] == original_desc
+
+    def test_empty_description_with_enrichment(self) -> None:
+        tool = _make_tool(description="", behavioral_what="Enhanced desc.")
+        fold_enrichment_into_description([tool])
+        assert tool["description"] == "[Enhanced Description]\nEnhanced desc."
+
+    def test_multiple_tools_all_folded(self) -> None:
+        tools = [
+            _make_tool(name="Read", behavioral_what="Read enhanced."),
+            _make_tool(name="Edit", behavioral_what="Edit enhanced."),
+        ]
+        fold_enrichment_into_description(tools)
+        assert "Read enhanced." in tools[0]["description"]
+        assert "Edit enhanced." in tools[1]["description"]
+
+    def test_multiple_enrichment_fields_all_folded(self) -> None:
+        tool = _make_tool(
+            behavioral_what="Enhanced.",
+            behavioral_why={"problem_context": "Need file content."},
+            _links={"related": ["Edit"]},
+        )
+        fold_enrichment_into_description([tool])
+        assert "[Enhanced Description]" in tool["description"]
+        assert "[Why Use This Tool]" in tool["description"]
+        assert "[Navigation]" in tool["description"]
+
+    def test_returns_same_list(self) -> None:
+        tools = [_make_tool()]
+        result = fold_enrichment_into_description(tools)
+        assert result is tools
+
+    def test_empty_list(self) -> None:
+        result = fold_enrichment_into_description([])
+        assert result == []
+
+
+class TestRemoveRemainingEnrichment:
+    """_remove_remaining_enrichment_fields cleans up."""
+
+    def test_removes_manifest(self) -> None:
+        tool = _make_tool(_manifest={"version": "1.0"})
+        _remove_remaining_enrichment_fields(tool)
+        assert "_manifest" not in tool
+
+    def test_removes_registration(self) -> None:
+        tool = _make_tool(_registration={"registered": True})
+        _remove_remaining_enrichment_fields(tool)
+        assert "_registration" not in tool
+
+    def test_preserves_base_fields(self) -> None:
+        tool = _make_tool()
+        _remove_remaining_enrichment_fields(tool)
+        assert "name" in tool
+        assert "description" in tool
+        assert "input_schema" in tool

--- a/translation/enrichment_folding.py
+++ b/translation/enrichment_folding.py
@@ -1,0 +1,243 @@
+"""Fold enrichment metadata into tool descriptions for OpenAI format.
+
+The OpenAI function-calling format only carries name, description, and
+parameters to the model. All other fields on the tool dict are silently
+discarded by the API. This module serializes enrichment metadata
+(behavioral dimensions, structural patterns) into the description field
+so the guest model actually receives the enrichment data.
+
+This runs AFTER the enrichment engine and BEFORE format translation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+# Enrichment field keys added by the engine, grouped by category.
+_BEHAVIORAL_FIELDS = ("behavioral_what", "behavioral_why", "behavioral_when")
+_STRUCTURAL_FIELDS = (
+    "_links",
+    "_near_miss",
+    "_error_format",
+    "_quality",
+    "_anti_patterns",
+    "outputSchema",
+    "_manifest",
+    "_registration",
+)
+
+# Fields that are part of the base Anthropic tool schema (not enrichment).
+_BASE_FIELDS = frozenset({"name", "description", "input_schema", "type", "cache_control"})
+
+
+def fold_enrichment_into_description(
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Append enrichment metadata to each tool's description.
+
+    Modifies tools in-place (caller is expected to pass a deep copy
+    from the enrichment engine). Returns the same list for chaining.
+
+    Each enrichment field is serialized as a labeled section appended
+    to the original description. The format is designed to be readable
+    by any LLM without special parsing.
+    """
+    for tool in tools:
+        sections: list[str] = []
+
+        # --- Behavioral dimensions ---
+        _fold_behavioral_what(tool, sections)
+        _fold_behavioral_why(tool, sections)
+        _fold_behavioral_when(tool, sections)
+
+        # --- Structural patterns ---
+        _fold_links(tool, sections)
+        _fold_error_format(tool, sections)
+        _fold_near_miss(tool, sections)
+        _fold_quality(tool, sections)
+        _fold_anti_patterns(tool, sections)
+        _fold_output_schema(tool, sections)
+
+        if sections:
+            original = tool.get("description", "")
+            enrichment_text = "\n".join(sections)
+            tool["description"] = (
+                f"{original}\n\n{enrichment_text}" if original else enrichment_text
+            )
+
+    return tools
+
+
+def _fold_behavioral_what(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold enhanced WHAT description."""
+    what = tool.pop("behavioral_what", None)
+    if what:
+        sections.append(f"[Enhanced Description]\n{what}")
+
+
+def _fold_behavioral_why(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold WHY context (problem context + failure modes)."""
+    why = tool.pop("behavioral_why", None)
+    if not why:
+        return
+    parts: list[str] = []
+    if isinstance(why, dict):
+        if "problem_context" in why:
+            parts.append(f"Problem context: {why['problem_context']}")
+        if "failure_modes" in why:
+            modes = why["failure_modes"]
+            if isinstance(modes, list):
+                for mode in modes:
+                    parts.append(f"- {mode}")
+            elif isinstance(modes, str):
+                parts.append(f"Failure modes: {modes}")
+    elif isinstance(why, str):
+        parts.append(why)
+    if parts:
+        sections.append(f"[Why Use This Tool]\n" + "\n".join(parts))
+
+
+def _fold_behavioral_when(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold WHEN context (prerequisites, sequencing, alternatives)."""
+    when = tool.pop("behavioral_when", None)
+    if not when:
+        return
+    parts: list[str] = []
+    if isinstance(when, dict):
+        if "prerequisites" in when:
+            prereqs = when["prerequisites"]
+            if isinstance(prereqs, list):
+                parts.append(f"Prerequisites: {', '.join(prereqs)}")
+            else:
+                parts.append(f"Prerequisites: {prereqs}")
+        if "use_before" in when:
+            parts.append(f"Use before: {', '.join(when['use_before'])}")
+        if "use_instead_of" in when:
+            parts.append(f"Use instead of: {', '.join(when['use_instead_of'])}")
+        if "do_not_use_for" in when:
+            items = when["do_not_use_for"]
+            if isinstance(items, list):
+                for item in items:
+                    parts.append(f"- Do NOT use for: {item}")
+            else:
+                parts.append(f"Do NOT use for: {items}")
+        if "sequencing" in when:
+            parts.append(f"Sequencing: {when['sequencing']}")
+    elif isinstance(when, str):
+        parts.append(when)
+    if parts:
+        sections.append(f"[When To Use]\n" + "\n".join(parts))
+
+
+def _fold_links(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold HATEOAS links (related tools, error recovery)."""
+    links = tool.pop("_links", None)
+    if not links:
+        return
+    parts: list[str] = []
+    if isinstance(links, dict):
+        if "related" in links:
+            related = links["related"]
+            if isinstance(related, list):
+                parts.append(f"Related tools: {', '.join(related)}")
+        if "on_error" in links:
+            on_error = links["on_error"]
+            if isinstance(on_error, dict):
+                for err_type, suggestion in on_error.items():
+                    parts.append(f"On {err_type}: {suggestion}")
+    if parts:
+        sections.append(f"[Navigation]\n" + "\n".join(parts))
+
+
+def _fold_error_format(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold error format documentation."""
+    error_fmt = tool.pop("_error_format", None)
+    if not error_fmt:
+        return
+    parts: list[str] = []
+    if isinstance(error_fmt, dict):
+        errors = error_fmt.get("errors", [])
+        if isinstance(errors, list):
+            for err in errors:
+                if isinstance(err, dict):
+                    error_str = err.get("error", "")
+                    suggestion = err.get("suggestion", "")
+                    parts.append(f"- {error_str}: {suggestion}")
+    if parts:
+        sections.append(f"[Error Handling]\n" + "\n".join(parts))
+
+
+def _fold_near_miss(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold near-miss alias data."""
+    near_miss = tool.pop("_near_miss", None)
+    if not near_miss:
+        return
+    parts: list[str] = []
+    if isinstance(near_miss, dict):
+        if "aliases" in near_miss:
+            parts.append(f"Also known as: {', '.join(near_miss['aliases'])}")
+        if "commonly_confused_with" in near_miss:
+            confused = near_miss["commonly_confused_with"]
+            if confused:
+                parts.append(f"Commonly confused with: {', '.join(confused)}")
+    if parts:
+        sections.append(f"[Aliases]\n" + "\n".join(parts))
+
+
+def _fold_quality(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold quality gate data."""
+    quality = tool.pop("_quality", None)
+    if not quality:
+        return
+    if isinstance(quality, dict):
+        parts: list[str] = []
+        for key, value in quality.items():
+            if isinstance(value, str):
+                parts.append(f"{key}: {value}")
+            else:
+                parts.append(f"{key}: {json.dumps(value, default=str)}")
+        if parts:
+            sections.append(f"[Quality]\n" + "\n".join(parts))
+
+
+def _fold_anti_patterns(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold anti-pattern documentation."""
+    anti = tool.pop("_anti_patterns", None)
+    if not anti:
+        return
+    parts: list[str] = []
+    if isinstance(anti, list):
+        for item in anti:
+            if isinstance(item, dict):
+                pattern = item.get("anti_pattern", "")
+                why_bad = item.get("why_bad", "")
+                do_instead = item.get("do_instead", "")
+                parts.append(f"- AVOID: {pattern}")
+                if why_bad:
+                    parts.append(f"  Why: {why_bad}")
+                if do_instead:
+                    parts.append(f"  Instead: {do_instead}")
+    if parts:
+        sections.append(f"[Anti-Patterns]\n" + "\n".join(parts))
+
+
+def _fold_output_schema(tool: dict[str, Any], sections: list[str]) -> None:
+    """Fold self-describing output schema."""
+    schema = tool.pop("outputSchema", None)
+    if not schema:
+        return
+    sections.append(
+        f"[Output Schema]\n{json.dumps(schema, indent=2, default=str)}"
+    )
+
+
+def _remove_remaining_enrichment_fields(tool: dict[str, Any]) -> None:
+    """Remove any enrichment fields not handled by specific folders.
+
+    Safety net: ensures no enrichment-only fields leak into the OpenAI
+    format where they would be silently discarded.
+    """
+    tool.pop("_manifest", None)
+    tool.pop("_registration", None)

--- a/translation/tools.py
+++ b/translation/tools.py
@@ -13,6 +13,10 @@ from typing import Any, Callable
 
 from bridge.logging_config import get_logger
 from bridge.token_logger import measure_enrichment_overhead
+from translation.enrichment_folding import (
+    fold_enrichment_into_description,
+    _remove_remaining_enrichment_fields,
+)
 
 logger = get_logger("forward")
 
@@ -90,8 +94,14 @@ def translate_tools(
             anthropic_tools, tools,
         )
 
+    # Fold enrichment metadata into descriptions so the guest model
+    # actually receives the data. The OpenAI function format only
+    # carries name/description/parameters — everything else is dropped.
+    fold_enrichment_into_description(tools)
+
     result: list[dict[str, Any]] = []
     for tool in tools:
+        _remove_remaining_enrichment_fields(tool)
         openai_tool: dict[str, Any] = {
             "type": "function",
             "function": {


### PR DESCRIPTION
## Summary

- Enrichment metadata (behavioral_what/why/when, _links, _near_miss, _error_format, _quality, _anti_patterns, outputSchema) was silently dropped during Anthropic-to-OpenAI tool translation because `translate_tools()` only carried `name`, `description`, and `parameters`
- The entire enrichment architecture was non-functional from the guest model's perspective -- only the system preamble reached the model
- New module `translation/enrichment_folding.py` serializes all enrichment fields as labeled text sections appended to the tool description before format translation
- The description field is the only reliable channel to the model in the OpenAI function format

## Changes

| File | Change |
|------|--------|
| `translation/enrichment_folding.py` | **NEW** -- Serializes enrichment fields into labeled description sections |
| `translation/tools.py` | Calls `fold_enrichment_into_description()` after enrichment hook, before format translation |
| `tests/translation/test_enrichment_folding.py` | **NEW** -- 32 tests covering all enrichment field types and edge cases |
| `tests/test_integration.py` | Updated assertion: description now starts with original text + enrichment appended |

## Design Decision

Chose Option 1 from the issue (fold into description) over Option 2 (metadata in parameters) because:
1. OpenAI/xAI APIs only guarantee `name`, `description`, and `parameters` reach the model
2. Unknown fields in the function schema may be silently dropped by the provider
3. The description is the single reliable channel

## Test plan

- [x] 32 new unit tests for enrichment folding (all field types, edge cases)
- [x] Updated integration test for enriched description behavior
- [x] Full test suite passes: 641 tests, 0 failures
- [ ] Kelvin: cross-review the enrichment text format for model readability

Fixes #35

Generated with [Claude Code](https://claude.com/claude-code)