### PR TITLE
refactor: Consolidate Responses API translation path

### DIFF
--- a/tests/translation/test_responses_forward.py
+++ b/tests/translation/test_responses_forward.py
@@ -11,8 +11,8 @@ from translation.responses_forward import (
     anthropic_to_responses,
     _translate_messages,
     _extract_tool_result,
-    _translate_tools_responses,
 )
+from translation.tools import translate_tools_responses as _translate_tools_responses
 
 
 class TestAnthropicToResponses:
@@ -211,7 +211,7 @@ class TestExtractToolResult:
 
 
 class TestTranslateToolsResponses:
-    """Tests for tool definition translation."""
+    """Tests for tool definition translation to Responses API format."""
 
     def test_flat_structure(self):
         anthropic_tools = [

--- a/tests/translation/test_shared.py
+++ b/tests/translation/test_shared.py
@@ -1,0 +1,47 @@
+"""Tests for shared translation utilities."""
+
+import pytest
+
+from translation.shared import flatten_system
+
+
+class TestFlattenSystem:
+    """Tests for the shared flatten_system() function."""
+
+    def test_string_passthrough(self):
+        assert flatten_system("Hello world.") == "Hello world."
+
+    def test_empty_string(self):
+        assert flatten_system("") == ""
+
+    def test_single_text_block(self):
+        system = [{"type": "text", "text": "You are a coding assistant."}]
+        assert flatten_system(system) == "You are a coding assistant."
+
+    def test_multiple_text_blocks(self):
+        system = [
+            {"type": "text", "text": "First block."},
+            {"type": "text", "text": "Second block."},
+        ]
+        assert flatten_system(system) == "First block.\n\nSecond block."
+
+    def test_non_text_blocks_skipped(self):
+        system = [
+            {"type": "text", "text": "Content here."},
+            {"type": "cache_control", "data": "ephemeral"},
+        ]
+        assert flatten_system(system) == "Content here."
+
+    def test_empty_list(self):
+        assert flatten_system([]) == ""
+
+    def test_empty_text_skipped(self):
+        system = [
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "Instructions."},
+        ]
+        assert flatten_system(system) == "Instructions."
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="Expected str or list"):
+            flatten_system(123)  # type: ignore[arg-type]

--- a/tests/translation/test_tools_responses.py
+++ b/tests/translation/test_tools_responses.py
@@ -1,0 +1,118 @@
+"""Tests for translate_tools_responses() and enrich_tools() in tools.py.
+
+Validates that the Responses API tool translation produces flat format
+directly from Anthropic input, without the intermediate Chat Completions
+hop that existed before issue #53 consolidation.
+"""
+
+from typing import Any
+
+from translation.tools import (
+    enrich_tools,
+    translate_tools,
+    translate_tools_responses,
+)
+
+
+class TestEnrichTools:
+    """Tests for the shared enrichment core."""
+
+    def test_empty_tools(self):
+        assert enrich_tools([]) == []
+
+    def test_preserves_name_description_schema(self):
+        tools = [
+            {
+                "name": "Read",
+                "description": "Read a file",
+                "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}},
+            }
+        ]
+        result = enrich_tools(tools)
+        assert len(result) == 1
+        assert result[0]["name"] == "Read"
+        assert result[0]["description"] == "Read a file"
+        assert result[0]["input_schema"] == {"type": "object", "properties": {"path": {"type": "string"}}}
+
+
+class TestTranslateToolsResponses:
+    """Tests for Responses API tool formatting."""
+
+    def test_flat_format(self):
+        tools = [
+            {
+                "name": "Bash",
+                "description": "Run a command",
+                "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}},
+            }
+        ]
+        result = translate_tools_responses(tools)
+        assert len(result) == 1
+        t = result[0]
+        assert t["type"] == "function"
+        assert t["name"] == "Bash"
+        assert t["description"] == "Run a command"
+        assert t["parameters"] == {"type": "object", "properties": {"command": {"type": "string"}}}
+        # Flat format -- no nested 'function' key.
+        assert "function" not in t
+
+    def test_multiple_tools(self):
+        tools = [
+            {"name": "Read", "description": "Read", "input_schema": {}},
+            {"name": "Write", "description": "Write", "input_schema": {}},
+        ]
+        result = translate_tools_responses(tools)
+        assert len(result) == 2
+        assert result[0]["name"] == "Read"
+        assert result[1]["name"] == "Write"
+
+    def test_empty_tools(self):
+        assert translate_tools_responses([]) == []
+
+
+class TestTranslateToolsChatCompletions:
+    """Tests for Chat Completions tool formatting (existing path)."""
+
+    def test_nested_format(self):
+        tools = [
+            {
+                "name": "Read",
+                "description": "Read a file",
+                "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}},
+            }
+        ]
+        result = translate_tools(tools)
+        assert len(result) == 1
+        t = result[0]
+        assert t["type"] == "function"
+        assert "function" in t
+        assert t["function"]["name"] == "Read"
+        assert t["function"]["description"] == "Read a file"
+        assert t["function"]["parameters"] == {"type": "object", "properties": {"path": {"type": "string"}}}
+
+
+class TestFormatConsistency:
+    """Tests that both format paths produce equivalent data from the same input."""
+
+    def test_same_enrichment_different_format(self):
+        tools = [
+            {
+                "name": "Grep",
+                "description": "Search files",
+                "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}}},
+            }
+        ]
+        chat_result = translate_tools(tools)
+        responses_result = translate_tools_responses(tools)
+
+        # Both should carry the same semantic content.
+        chat_func = chat_result[0]["function"]
+        resp_tool = responses_result[0]
+
+        assert chat_func["name"] == resp_tool["name"]
+        assert chat_func["description"] == resp_tool["description"]
+        assert chat_func["parameters"] == resp_tool["parameters"]
+
+        # But in different structures.
+        assert "function" in chat_result[0]
+        assert "function" not in responses_result[0]

--- a/translation/__init__.py
+++ b/translation/__init__.py
@@ -12,9 +12,11 @@ from translation.reverse import openai_to_anthropic, translate_response, unescap
 from translation.streaming import translate_sse_event, OpenAIToAnthropicStreamAdapter
 from translation.config import TranslationConfig
 from translation.model_routing import detect_endpoint, XAIEndpoint
+from translation.shared import flatten_system
 from translation.responses_forward import anthropic_to_responses
 from translation.responses_reverse import responses_to_anthropic, translate_responses_response
 from translation.responses_streaming import ResponsesStreamAdapter
+from translation.tools import enrich_tools, translate_tools_responses
 
 __all__ = [
     "anthropic_to_openai",
@@ -29,8 +31,11 @@ __all__ = [
     "TranslationConfig",
     "detect_endpoint",
     "XAIEndpoint",
+    "flatten_system",
     "anthropic_to_responses",
     "responses_to_anthropic",
     "translate_responses_response",
     "ResponsesStreamAdapter",
+    "enrich_tools",
+    "translate_tools_responses",
 ]

--- a/translation/forward.py
+++ b/translation/forward.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from bridge.logging_config import get_logger
 from translation.config import TranslationConfig, UNSUPPORTED_FEATURES, STRIPPED_FEATURES
+from translation.shared import flatten_system as _flatten_system
 from translation.tools import translate_tools as _translate_tools
 from enrichment.system_preamble import strip_anthropic_identity
 
@@ -67,29 +68,6 @@ def strip_thinking(request: dict[str, Any]) -> list[str]:
                     )
 
     return warnings
-
-
-def _flatten_system(system: str | list[dict[str, Any]]) -> str:
-    """Flatten a system prompt to a single string.
-
-    Handles both Anthropic system prompt formats:
-    - String: returned as-is
-    - List of content blocks: text blocks are joined with newlines,
-      non-text blocks are skipped
-    """
-    if isinstance(system, str):
-        return system
-    if isinstance(system, list):
-        parts: list[str] = []
-        for block in system:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text", "")
-                if text:
-                    parts.append(text)
-        return "\n\n".join(parts)
-    raise TypeError(
-        f"Expected str or list for system field, got {type(system).__name__}"
-    )
 
 
 def anthropic_to_openai(request: dict[str, Any]) -> dict[str, Any]:

--- a/translation/responses_forward.py
+++ b/translation/responses_forward.py
@@ -17,7 +17,8 @@ from typing import Any
 
 from bridge.logging_config import get_logger
 from translation.config import TranslationConfig, UNSUPPORTED_FEATURES
-from translation.tools import translate_tools as _translate_tools_chat
+from translation.shared import flatten_system
+from translation.tools import translate_tools_responses as _translate_tools_responses
 from enrichment.system_preamble import strip_anthropic_identity
 
 _config = TranslationConfig()
@@ -48,7 +49,7 @@ def anthropic_to_responses(request: dict[str, Any]) -> dict[str, Any]:
     # System prompt -> first message with role 'system' in input array.
     raw_system = request.get("system", "")
     stripped = strip_anthropic_identity(raw_system)
-    system = _flatten_system(stripped)
+    system = flatten_system(stripped)
     preamble = _config.system_prompt_preamble
     if preamble and system:
         system = f"{preamble}\n\n{system}"
@@ -66,60 +67,12 @@ def anthropic_to_responses(request: dict[str, Any]) -> dict[str, Any]:
         "stream": bool(request.get("stream")),
     }
 
-    # Translate tools to Responses API format.
+    # Translate tools to Responses API format (enrichment runs inside).
     tools = request.get("tools")
     if tools:
         result["tools"] = _translate_tools_responses(tools)
 
     return result
-
-
-def _flatten_system(system: str | list[dict[str, Any]]) -> str:
-    """Flatten a system prompt to a single string.
-
-    Handles both Anthropic formats: plain string or list of content blocks.
-    """
-    if isinstance(system, str):
-        return system
-    if isinstance(system, list):
-        parts: list[str] = []
-        for block in system:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text", "")
-                if text:
-                    parts.append(text)
-        return "\n\n".join(parts)
-    raise TypeError(
-        f"Expected str or list for system field, got {type(system).__name__}"
-    )
-
-
-def _translate_tools_responses(
-    anthropic_tools: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Translate Anthropic tools to Responses API format.
-
-    Responses API tools have a flatter structure:
-    {type: "function", name: "...", description: "...", parameters: {...}}
-
-    Unlike Chat Completions which nests under 'function' key.
-    Enrichment hooks still run at the Anthropic level via _translate_tools_chat.
-    """
-    # Run enrichment hook at Anthropic level (via the chat tools module).
-    # This calls the enrichment hook and measures overhead.
-    chat_tools = _translate_tools_chat(anthropic_tools)
-
-    # Convert from Chat Completions format to Responses API format.
-    responses_tools: list[dict[str, Any]] = []
-    for ct in chat_tools:
-        func = ct.get("function", {})
-        responses_tools.append({
-            "type": "function",
-            "name": func.get("name", ""),
-            "description": func.get("description", ""),
-            "parameters": func.get("parameters", {}),
-        })
-    return responses_tools
 
 
 def _translate_messages(

--- a/translation/shared.py
+++ b/translation/shared.py
@@ -1,0 +1,40 @@
+"""Shared translation utilities used by both Responses and Chat Completions paths.
+
+Prevents duplication between forward.py (legacy) and responses_forward.py (default).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def flatten_system(system: str | list[dict[str, Any]]) -> str:
+    """Flatten a system prompt to a single string.
+
+    Handles both Anthropic system prompt formats:
+    - String: returned as-is
+    - List of content blocks: text blocks are joined with double newlines,
+      non-text blocks are skipped
+
+    Args:
+        system: The system prompt in either Anthropic format.
+
+    Returns:
+        A single string suitable for the xAI system message.
+
+    Raises:
+        TypeError: If system is neither str nor list.
+    """
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        parts: list[str] = []
+        for block in system:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                if text:
+                    parts.append(text)
+        return "\n\n".join(parts)
+    raise TypeError(
+        f"Expected str or list for system field, got {type(system).__name__}"
+    )

--- a/translation/tools.py
+++ b/translation/tools.py
@@ -1,7 +1,11 @@
-"""Tool definition translation between Anthropic and OpenAI formats.
+"""Tool definition translation between Anthropic and xAI formats.
 
-Forward: Anthropic {name, description, input_schema} ->
-         OpenAI {type: "function", function: {name, description, parameters}}
+Two output formats:
+- Chat Completions: {type: "function", function: {name, description, parameters}}
+- Responses API: {type: "function", name: ..., description: ..., parameters: ...}
+
+Both share the same enrichment pipeline (hook + folding + cleanup).
+The core enrichment runs once; formatting is the final step.
 
 Enrichment injection point: hook to modify tool definitions before translation.
 Measures enrichment overhead for token logging (Issue #26).
@@ -29,7 +33,7 @@ ToolEnrichmentHook = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
 _tool_enrichment_hook: ToolEnrichmentHook | None = None
 
 # Last measured enrichment overhead in estimated tokens.
-# Updated on every translate_tools() call where enrichment runs.
+# Updated on every enrich_tools() call where enrichment runs.
 # Read by main.py to include in token usage logging.
 _last_enrichment_overhead: int = 0
 
@@ -46,10 +50,10 @@ def set_tool_enrichment_hook(hook: ToolEnrichmentHook | None) -> None:
 
 
 def get_last_enrichment_overhead() -> int:
-    """Return the enrichment overhead from the most recent translate_tools() call.
+    """Return the enrichment overhead from the most recent enrich_tools() call.
 
     Returns estimated token count added by enrichment. Resets to 0 on
-    each translate_tools() call before measurement.
+    each enrich_tools() call before measurement.
     """
     return _last_enrichment_overhead
 
@@ -65,16 +69,21 @@ def reset_enrichment_overhead() -> None:
     _last_enrichment_overhead = 0
 
 
-def translate_tools(
+def enrich_tools(
     anthropic_tools: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Translate Anthropic tool definitions to OpenAI function format.
+    """Run enrichment pipeline on Anthropic tool definitions.
+
+    This is the shared core: enrichment hook + description folding +
+    cleanup of enrichment-only fields. The result is a list of dicts
+    with {name, description, input_schema} -- format-neutral, ready
+    for either Chat Completions or Responses API formatting.
 
     Args:
         anthropic_tools: List of Anthropic tool defs with input_schema.
 
     Returns:
-        List of OpenAI function tool defs with parameters.
+        Enriched tool defs (name, description, input_schema only).
     """
     global _last_enrichment_overhead
     _last_enrichment_overhead = 0
@@ -95,13 +104,33 @@ def translate_tools(
         )
 
     # Fold enrichment metadata into descriptions so the guest model
-    # actually receives the data. The OpenAI function format only
-    # carries name/description/parameters — everything else is dropped.
+    # actually receives the data. Both xAI formats only carry
+    # name/description/parameters -- everything else is dropped.
     fold_enrichment_into_description(tools)
 
-    result: list[dict[str, Any]] = []
     for tool in tools:
         _remove_remaining_enrichment_fields(tool)
+
+    return tools
+
+
+def translate_tools(
+    anthropic_tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Translate Anthropic tool definitions to OpenAI Chat Completions format.
+
+    Chat Completions format: {type: "function", function: {name, description, parameters}}
+
+    Args:
+        anthropic_tools: List of Anthropic tool defs with input_schema.
+
+    Returns:
+        List of OpenAI function tool defs with parameters.
+    """
+    enriched = enrich_tools(anthropic_tools)
+
+    result: list[dict[str, Any]] = []
+    for tool in enriched:
         openai_tool: dict[str, Any] = {
             "type": "function",
             "function": {
@@ -111,5 +140,33 @@ def translate_tools(
             },
         }
         result.append(openai_tool)
+
+    return result
+
+
+def translate_tools_responses(
+    anthropic_tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Translate Anthropic tool definitions to xAI Responses API format.
+
+    Responses API format: {type: "function", name: ..., description: ..., parameters: ...}
+    Flat structure -- no nested 'function' key.
+
+    Args:
+        anthropic_tools: List of Anthropic tool defs with input_schema.
+
+    Returns:
+        List of Responses API function tool defs.
+    """
+    enriched = enrich_tools(anthropic_tools)
+
+    result: list[dict[str, Any]] = []
+    for tool in enriched:
+        result.append({
+            "type": "function",
+            "name": tool["name"],
+            "description": tool.get("description", ""),
+            "parameters": tool.get("input_schema", {}),
+        })
 
     return result


### PR DESCRIPTION
## Summary

Closes #53. Eliminates duplication in the Responses API translation path after PR #55 made it the default for all models.

- **Extracted `flatten_system()`** to `translation/shared.py` -- was duplicated identically in both `forward.py` and `responses_forward.py`
- **Extracted `enrich_tools()` core** from `translate_tools()` in `tools.py` -- the enrichment pipeline (hook + folding + cleanup) is now a shared function that both format paths call
- **Added `translate_tools_responses()`** -- translates Anthropic tools directly to Responses API flat format (`{type, name, description, parameters}`), eliminating the previous two-hop path that went Anthropic -> Chat Completions -> Responses
- **Removed `_flatten_system` and `_translate_tools_responses`** from `responses_forward.py` -- now imports from shared modules
- **15 new tests** covering `shared.py`, `enrich_tools()`, `translate_tools_responses()`, and format consistency between both paths

### What was wrong before

The Responses API tool translation in `responses_forward.py` called `translate_tools()` (which produces Chat Completions format with nested `function` key), then immediately unwrapped the `function` dict to produce Responses API flat format. This was an unnecessary round-trip through the wrong format.

### What changed

Both paths now call `enrich_tools()` for the shared enrichment pipeline, then apply their own format-specific output:
- Chat Completions: `translate_tools()` wraps in `{type: "function", function: {name, desc, params}}`
- Responses API: `translate_tools_responses()` produces `{type: "function", name, desc, params}`

### Files NOT touched (owned by #52)
- `handlers/chat_completions.py`
- `main.py`

## Test plan

- [x] All 660 tests pass (645 existing + 15 new)
- [x] Existing `test_responses_forward.py` tests pass with updated imports
- [x] New `test_shared.py` covers `flatten_system()` edge cases
- [x] New `test_tools_responses.py` validates format consistency between both paths
- [x] Multi-agent tool serialization preserved (Responses API flat format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)