### PR TITLE
test: Clean up test suite after Responses API migration

### DIFF
--- a/tests/bridge/test_token_integration.py
+++ b/tests/bridge/test_token_integration.py
@@ -3,6 +3,8 @@
 Verifies that token usage logs appear at INFO level for both
 non-streaming and streaming requests, and that enrichment overhead
 is captured when tools are present.
+
+Mock responses use Responses API format (the PRIMARY path since issue #51).
 """
 
 from __future__ import annotations
@@ -35,32 +37,26 @@ def _mock_xai_response(data: dict, status_code: int = 200):
 
 
 _SIMPLE_RESPONSE = {
-    "id": "chatcmpl-token1",
-    "object": "chat.completion",
-    "choices": [{
-        "index": 0,
-        "message": {"role": "assistant", "content": "Hello!"},
-        "finish_reason": "stop",
-    }],
-    "usage": {"prompt_tokens": 42, "completion_tokens": 8, "total_tokens": 50},
+    "id": "resp_token1",
+    "output": [
+        {"type": "message", "content": [{"type": "output_text", "text": "Hello!"}]},
+    ],
+    "model": "grok-4-1-fast-reasoning",
+    "usage": {"input_tokens": 42, "output_tokens": 8},
 }
 
 _TOOL_CALL_RESPONSE = {
-    "id": "chatcmpl-token2",
-    "object": "chat.completion",
-    "choices": [{
-        "index": 0,
-        "message": {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {"id": "call_1", "type": "function",
-                 "function": {"name": "Read", "arguments": '{"file_path": "/tmp/x"}'}},
-            ],
+    "id": "resp_token2",
+    "output": [
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "Read",
+            "arguments": '{"file_path": "/tmp/x"}',
         },
-        "finish_reason": "tool_calls",
-    }],
-    "usage": {"prompt_tokens": 200, "completion_tokens": 30, "total_tokens": 230},
+    ],
+    "model": "grok-4-1-fast-reasoning",
+    "usage": {"input_tokens": 200, "output_tokens": 30},
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,10 +166,36 @@ def anthropic_simple_request() -> dict[str, Any]:
 
 
 @pytest.fixture
-def openai_simple_response() -> dict[str, Any]:
-    """A basic OpenAI Chat Completions response.
+def responses_api_simple_response() -> dict[str, Any]:
+    """A basic xAI Responses API response.
 
-    Standard non-streaming response with a single choice and usage stats.
+    Standard non-streaming response with output array and usage stats.
+    This is the PRIMARY format since issue #51.
+    """
+    return {
+        "id": "resp_test123",
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "I'm doing well, thank you! How can I help you?"},
+                ],
+            }
+        ],
+        "model": "grok-4-1-fast-reasoning",
+        "usage": {
+            "input_tokens": 15,
+            "output_tokens": 12,
+        },
+    }
+
+
+@pytest.fixture
+def openai_simple_response() -> dict[str, Any]:
+    """LEGACY: OpenAI Chat Completions response format.
+
+    Retained for testing the legacy translation.reverse module.
+    The primary path now uses Responses API format (see responses_api_simple_response).
     """
     return {
         "id": "chatcmpl-test123",

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -77,25 +77,17 @@ SAMPLE_REQUEST = {
 }
 
 MOCK_XAI_RESPONSE = {
-    "id": "chatcmpl-smoke-001",
-    "object": "chat.completion",
-    "choices": [{
-        "index": 0,
-        "message": {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [{
-                "id": "call_smoke_001",
-                "type": "function",
-                "function": {
-                    "name": "Read",
-                    "arguments": json.dumps({"file_path": "/tmp/test.py"}),
-                },
-            }],
-        },
-        "finish_reason": "tool_calls",
-    }],
-    "usage": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70},
+    "id": "resp_smoke_001",
+    "output": [
+        {
+            "type": "function_call",
+            "call_id": "call_smoke_001",
+            "name": "Read",
+            "arguments": json.dumps({"file_path": "/tmp/test.py"}),
+        }
+    ],
+    "model": "grok-4-1-fast-reasoning",
+    "usage": {"input_tokens": 50, "output_tokens": 20},
 }
 
 
@@ -233,22 +225,25 @@ def check_translation_mock(client: TestClient, r: Results) -> None:
     else:
         r.ok("translation.model_map", f"→ {model}")
 
-    # Verify system prompt was injected
-    msgs = captured.get("messages", [])
-    system_msgs = [m for m in msgs if m.get("role") == "system"]
+    # Verify system prompt was injected (Responses API uses 'input' array with system role)
+    input_msgs = captured.get("input", captured.get("messages", []))
+    system_msgs = [m for m in input_msgs if m.get("role") == "system"]
     if system_msgs:
         r.ok("translation.system_prompt", f"{len(system_msgs[0]['content'])} chars")
     else:
         r.ok("translation.system_prompt", "no system message (preamble may be disabled)")
 
-    # Verify tools were translated to OpenAI format
+    # Verify tools were translated to Responses API format
     tools = captured.get("tools", [])
     if not tools:
         r.fail("translation.tools_forward", "no tools in captured request")
     elif tools[0].get("type") != "function":
         r.fail("translation.tools_forward", f"expected type=function, got {tools[0].get('type')}")
     else:
-        r.ok("translation.tools_forward", f"{len(tools)} tools translated to OpenAI format")
+        # Responses API tools have flat format (no nested 'function' key)
+        has_function_key = "function" in tools[0]
+        fmt = "Chat Completions (nested)" if has_function_key else "Responses API (flat)"
+        r.ok("translation.tools_forward", f"{len(tools)} tools translated to {fmt} format")
 
     # Verify response translation
     data = resp.json()
@@ -303,10 +298,12 @@ def check_thinking_stripped(client: TestClient, r: Results) -> None:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {
-            "id": "chatcmpl-smoke-002",
-            "object": "chat.completion",
-            "choices": [{"index": 0, "message": {"role": "assistant", "content": "OK"}, "finish_reason": "stop"}],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+            "id": "resp_smoke_002",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "OK"}]},
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {"input_tokens": 10, "output_tokens": 2},
         }
         return mock_resp
 

--- a/tests/translation/conftest.py
+++ b/tests/translation/conftest.py
@@ -1,7 +1,13 @@
-"""Translation-specific conftest — parametrized fixtures for message type coverage.
+"""Translation-specific conftest -- parametrized fixtures for message type coverage.
 
 Imports from fixture files and provides parametrized combinations
 for exhaustive testing of the translation layer.
+
+Fixtures are organized as:
+- Anthropic message fixtures (used by all paths)
+- LEGACY: OpenAI Chat Completions response fixtures (translation.reverse)
+- PRIMARY: Responses API response fixtures (translation.responses_reverse)
+- Streaming event fixtures (both legacy CC and primary Responses API)
 """
 
 import pytest
@@ -16,7 +22,7 @@ from tests.translation.fixtures.anthropic_messages import (
     parallel_tool_calls,
     full_request_with_tools,
 )
-from tests.translation.fixtures.openai_completions import (
+from tests.translation.fixtures.openai_completions import (  # LEGACY CC fixtures
     simple_completion,
     tool_call_completion,
     multi_tool_call_completion,
@@ -27,6 +33,14 @@ from tests.translation.fixtures.openai_completions import (
     error_response_429,
     error_response_500,
     error_response_400,
+)
+from tests.translation.fixtures.responses_api import (  # PRIMARY Responses API fixtures
+    simple_response as responses_simple,
+    function_call_response as responses_function_call,
+    multi_function_call_response as responses_multi_function_call,
+    error_response_429 as responses_error_429,
+    error_response_500 as responses_error_500,
+    error_response_400 as responses_error_400,
 )
 from tests.translation.fixtures.streaming_events import (
     anthropic_message_start,
@@ -91,13 +105,13 @@ def anthropic_full_request() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# OpenAI response fixtures
+# LEGACY: OpenAI Chat Completions response fixtures
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
 def openai_text_response() -> dict[str, Any]:
-    """Simple text completion response."""
+    """LEGACY: Simple CC text completion response."""
     return simple_completion()
 
 
@@ -156,6 +170,29 @@ def openai_bad_request_error() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# PRIMARY: Responses API response fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def responses_api_text_response() -> dict[str, Any]:
+    """PRIMARY: Simple Responses API text response."""
+    return responses_simple()
+
+
+@pytest.fixture
+def responses_api_tool_response() -> dict[str, Any]:
+    """PRIMARY: Responses API response with function_call."""
+    return responses_function_call()
+
+
+@pytest.fixture
+def responses_api_multi_tool_response() -> dict[str, Any]:
+    """PRIMARY: Responses API response with multiple function_calls."""
+    return responses_multi_function_call()
+
+
+# ---------------------------------------------------------------------------
 # Streaming event fixtures
 # ---------------------------------------------------------------------------
 
@@ -168,13 +205,13 @@ def anthropic_stream_events() -> list[dict[str, Any]]:
 
 @pytest.fixture
 def openai_stream_lines() -> list[str]:
-    """Complete OpenAI SSE data lines for a text response."""
+    """LEGACY: Complete CC SSE data lines for a text response."""
     return openai_stream_chunks()
 
 
 @pytest.fixture
 def openai_tool_stream_lines() -> list[str]:
-    """Complete OpenAI SSE data lines for a tool call response."""
+    """LEGACY: Complete CC SSE data lines for a tool call response."""
     return openai_tool_call_stream_chunks()
 
 
@@ -210,11 +247,28 @@ def anthropic_message_variant(request: pytest.FixtureRequest) -> dict[str, Any]:
     ]
 )
 def openai_response_variant(request: pytest.FixtureRequest) -> dict[str, Any]:
-    """Parametrized fixture providing each OpenAI response type."""
+    """LEGACY: Parametrized fixture providing each CC response type."""
     variants = {
         "text": simple_completion,
         "tool_call": tool_call_completion,
         "multi_tool": multi_tool_call_completion,
+    }
+    return variants[request.param]()
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("text", id="responses-text"),
+        pytest.param("function_call", id="responses-function-call"),
+        pytest.param("multi_function_call", id="responses-multi-function-call"),
+    ]
+)
+def responses_api_response_variant(request: pytest.FixtureRequest) -> dict[str, Any]:
+    """PRIMARY: Parametrized fixture providing each Responses API response type."""
+    variants = {
+        "text": responses_simple,
+        "function_call": responses_function_call,
+        "multi_function_call": responses_multi_function_call,
     }
     return variants[request.param]()
 
@@ -229,11 +283,31 @@ def openai_response_variant(request: pytest.FixtureRequest) -> dict[str, Any]:
 def openai_error_variant(
     request: pytest.FixtureRequest,
 ) -> tuple[int, dict[str, Any]]:
-    """Parametrized fixture providing each OpenAI error type with status code."""
+    """LEGACY: Parametrized fixture providing each CC error type with status code."""
     variants: dict[str, tuple[int, Any]] = {
         "rate_limit": (429, error_response_429),
         "server_error": (500, error_response_500),
         "bad_request": (400, error_response_400),
+    }
+    status_code, factory = variants[request.param]
+    return status_code, factory()
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("rate_limit", id="responses-429-rate-limit"),
+        pytest.param("server_error", id="responses-500-server-error"),
+        pytest.param("bad_request", id="responses-400-bad-request"),
+    ]
+)
+def responses_api_error_variant(
+    request: pytest.FixtureRequest,
+) -> tuple[int, dict[str, Any]]:
+    """PRIMARY: Parametrized fixture providing each Responses API error with status code."""
+    variants: dict[str, tuple[int, Any]] = {
+        "rate_limit": (429, responses_error_429),
+        "server_error": (500, responses_error_500),
+        "bad_request": (400, responses_error_400),
     }
     status_code, factory = variants[request.param]
     return status_code, factory()

--- a/tests/translation/fixtures/openai_completions.py
+++ b/tests/translation/fixtures/openai_completions.py
@@ -1,7 +1,11 @@
-"""Sample OpenAI Chat Completions API payloads for translation testing.
+"""LEGACY: Sample OpenAI Chat Completions API payloads for translation testing.
 
-These fixtures represent what xAI/Grok returns. The reverse translator
-converts these into Anthropic Messages API format for Claude Code.
+These fixtures represent the LEGACY Chat Completions format that xAI/Grok
+used to return before issue #51 migrated to the Responses API. They are
+retained for testing the legacy translation.reverse and translation.streaming
+modules which still handle this format when XAI_USE_CHAT_COMPLETIONS=true.
+
+For PRIMARY path fixtures, see tests/translation/fixtures/responses_api.py.
 """
 
 from typing import Any

--- a/tests/translation/fixtures/responses_api.py
+++ b/tests/translation/fixtures/responses_api.py
@@ -1,0 +1,149 @@
+"""Sample xAI Responses API payloads for translation testing.
+
+These fixtures represent what xAI/Grok returns via the Responses API,
+which is the PRIMARY path since issue #51. The reverse translator
+(translation.responses_reverse) converts these into Anthropic Messages
+API format for Claude Code.
+"""
+
+from typing import Any
+
+
+def simple_response() -> dict[str, Any]:
+    """Basic text response from the Responses API."""
+    return {
+        "id": "resp_abc123def456",
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "Hello! How can I help you today?"},
+                ],
+            }
+        ],
+        "model": "grok-4-1-fast-reasoning",
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 9,
+        },
+    }
+
+
+def function_call_response() -> dict[str, Any]:
+    """Response where the model invokes a tool via function_call.
+
+    Responses API format puts function calls as top-level output items
+    with type 'function_call', call_id, name, and arguments (JSON string).
+    """
+    return {
+        "id": "resp_tool789xyz",
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": "call_abc123",
+                "name": "Read",
+                "arguments": '{"file_path": "/home/user/project/main.py"}',
+            }
+        ],
+        "model": "grok-4-1-fast-reasoning",
+        "usage": {
+            "input_tokens": 150,
+            "output_tokens": 25,
+        },
+    }
+
+
+def multi_function_call_response() -> dict[str, Any]:
+    """Response with text and multiple parallel function calls."""
+    return {
+        "id": "resp_multi456",
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "I'll read both files to compare them."},
+                ],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_read_old",
+                "name": "Read",
+                "arguments": '{"file_path": "/home/user/project/old.py"}',
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_read_new",
+                "name": "Read",
+                "arguments": '{"file_path": "/home/user/project/new.py"}',
+            },
+        ],
+        "model": "grok-4-1-fast-reasoning",
+        "usage": {
+            "input_tokens": 200,
+            "output_tokens": 45,
+        },
+    }
+
+
+def reasoning_response() -> dict[str, Any]:
+    """Response containing a reasoning block (should be stripped)."""
+    return {
+        "id": "resp_reasoning789",
+        "output": [
+            {"type": "reasoning", "encrypted_content": "abc123..."},
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "The answer is 42."},
+                ],
+            },
+        ],
+        "model": "grok-4-1-fast-reasoning",
+        "usage": {
+            "input_tokens": 50,
+            "output_tokens": 20,
+        },
+    }
+
+
+def empty_output_response() -> dict[str, Any]:
+    """Response with empty output array."""
+    return {
+        "id": "resp_empty",
+        "output": [],
+        "model": "grok-4-1-fast-reasoning",
+        "usage": {},
+    }
+
+
+def error_response_429() -> dict[str, Any]:
+    """Rate limit error from the xAI Responses API."""
+    return {
+        "error": {
+            "message": "Rate limit exceeded. Please retry after 30 seconds.",
+            "type": "rate_limit_error",
+            "code": "rate_limit_exceeded",
+        }
+    }
+
+
+def error_response_500() -> dict[str, Any]:
+    """Internal server error from the xAI Responses API."""
+    return {
+        "error": {
+            "message": "Internal server error. The model encountered an unexpected condition.",
+            "type": "server_error",
+            "code": "internal_error",
+        }
+    }
+
+
+def error_response_400() -> dict[str, Any]:
+    """Bad request error -- malformed input."""
+    return {
+        "error": {
+            "message": "Invalid value for 'input[0].content': expected string or array.",
+            "type": "invalid_request_error",
+            "code": "invalid_value",
+        }
+    }

--- a/tests/translation/fixtures/streaming_events.py
+++ b/tests/translation/fixtures/streaming_events.py
@@ -3,6 +3,13 @@
 Anthropic and OpenAI use different SSE event formats. These fixtures
 provide the raw event data for both sides so the streaming translator
 can be validated.
+
+Sections:
+- Anthropic SSE events: what Claude Code expects to receive (used by all paths)
+- OpenAI SSE events: LEGACY Chat Completions streaming format
+  (used by translation.streaming when XAI_USE_CHAT_COMPLETIONS=true)
+- For Responses API streaming fixtures, see test_responses_streaming.py
+  which builds SSE lines inline using _data_line() helper.
 """
 
 import json
@@ -143,7 +150,9 @@ def anthropic_full_text_stream() -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
-# OpenAI SSE data lines (what xAI/Grok actually sends over the wire)
+# LEGACY: OpenAI Chat Completions SSE data lines
+# Used by translation.streaming (Chat Completions streaming adapter).
+# The primary path now uses Responses API streaming (see test_responses_streaming.py).
 # ---------------------------------------------------------------------------
 
 

--- a/tests/translation/test_edge_cases.py
+++ b/tests/translation/test_edge_cases.py
@@ -2,7 +2,12 @@
 
 These tests cover unusual, malformed, or boundary-condition inputs that
 the translator must handle gracefully. Real-world traffic from Claude Code
-and xAI will include unexpected payloads — the translator must never crash.
+and xAI will include unexpected payloads -- the translator must never crash.
+
+Tests are organized as:
+- Forward translation edge cases (Anthropic -> xAI, shared by both paths)
+- LEGACY reverse edge cases (OpenAI CC -> Anthropic, via translation.reverse)
+- PRIMARY reverse edge cases (Responses API -> Anthropic, via translation.responses_reverse)
 """
 
 import json
@@ -13,6 +18,7 @@ import pytest
 
 from translation.forward import anthropic_to_openai, translate_messages, translate_tools
 from translation.reverse import openai_to_anthropic, translate_response
+from translation.responses_reverse import responses_to_anthropic, translate_responses_response
 
 from tests.translation.fixtures.anthropic_messages import (
     simple_text_message,
@@ -21,6 +27,10 @@ from tests.translation.fixtures.anthropic_messages import (
 from tests.translation.fixtures.openai_completions import (
     simple_completion,
     tool_call_completion,
+)
+from tests.translation.fixtures.responses_api import (
+    simple_response as responses_simple,
+    function_call_response as responses_function_call,
 )
 
 
@@ -43,13 +53,22 @@ class TestEmptyContent:
         assert result[0]["content"] == ""
 
     def test_none_content_in_openai_response(self) -> None:
-        """A response with content=None (no tool_calls) should be handled."""
+        """LEGACY: A CC response with content=None (no tool_calls) should be handled."""
         response = simple_completion()
         response["choices"][0]["message"]["content"] = None
 
         result = openai_to_anthropic(response)
         # Should not crash; content should be an array (possibly with empty text)
         assert isinstance(result["content"], list)
+
+    def test_empty_output_in_responses_api(self) -> None:
+        """PRIMARY: A Responses API response with empty output should be handled."""
+        response = {"id": "resp_empty", "output": [], "model": "grok-4-1-fast-reasoning", "usage": {}}
+
+        result = responses_to_anthropic(response)
+        assert isinstance(result["content"], list)
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "text"
 
     def test_empty_text_block(self) -> None:
         """A text block with empty text should translate."""
@@ -201,12 +220,26 @@ class TestVeryLongContent:
         assert result[0]["content"].count("line") == 50_000
 
     def test_long_openai_response(self) -> None:
-        """A very long OpenAI response should translate without truncation."""
+        """LEGACY: A very long CC response should translate without truncation."""
         long_text = "word " * 20_000
         response = simple_completion()
         response["choices"][0]["message"]["content"] = long_text
 
         result = openai_to_anthropic(response)
+        assert result["content"][0]["text"] == long_text
+
+    def test_long_responses_api_response(self) -> None:
+        """PRIMARY: A very long Responses API response should translate without truncation."""
+        long_text = "word " * 20_000
+        response = {
+            "id": "resp_long",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": long_text}]},
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {},
+        }
+        result = responses_to_anthropic(response)
         assert result["content"][0]["text"] == long_text
 
 
@@ -339,7 +372,7 @@ class TestMissingOptionalFields:
         assert tools is None or tools == []
 
     def test_response_without_model_field(self) -> None:
-        """An OpenAI response missing the model field should still translate."""
+        """LEGACY: A CC response missing the model field should still translate."""
         response = simple_completion()
         del response["model"]
 
@@ -347,7 +380,7 @@ class TestMissingOptionalFields:
         assert result["content"][0]["type"] == "text"
 
     def test_response_without_created_field(self) -> None:
-        """An OpenAI response missing the created field should still translate."""
+        """LEGACY: A CC response missing the created field should still translate."""
         response = simple_completion()
         del response["created"]
 
@@ -355,7 +388,7 @@ class TestMissingOptionalFields:
         assert result["content"][0]["type"] == "text"
 
     def test_tool_call_without_type_field(self) -> None:
-        """A tool_call entry missing the type field should still translate."""
+        """LEGACY: A CC tool_call entry missing the type field should still translate."""
         response = tool_call_completion()
         del response["choices"][0]["message"]["tool_calls"][0]["type"]
 
@@ -363,12 +396,36 @@ class TestMissingOptionalFields:
         tool_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
         assert len(tool_blocks) == 1
 
+    def test_responses_api_missing_model(self) -> None:
+        """PRIMARY: Responses API response missing model field should still translate."""
+        response = responses_simple()
+        del response["model"]
+        result = responses_to_anthropic(response)
+        assert result["content"][0]["type"] == "text"
+
+    def test_responses_api_missing_usage(self) -> None:
+        """PRIMARY: Responses API response missing usage should provide defaults."""
+        response = responses_simple()
+        del response["usage"]
+        result = responses_to_anthropic(response)
+        assert result["usage"]["input_tokens"] >= 0
+        assert result["usage"]["output_tokens"] >= 0
+
+    def test_responses_api_invalid_arguments_json(self) -> None:
+        """PRIMARY: Responses API function_call with invalid JSON arguments."""
+        response = responses_function_call()
+        response["output"][0]["arguments"] = "not valid json"
+        result = responses_to_anthropic(response)
+        tool = result["content"][0]
+        assert tool["type"] == "tool_use"
+        assert tool["input"] == {}
+
 
 class TestUnknownFinishReason:
-    """Handling of unexpected or future finish_reason values."""
+    """LEGACY: Handling of unexpected or future finish_reason values (CC path)."""
 
     def test_unknown_finish_reason_does_not_crash(self) -> None:
-        """An unrecognized finish_reason should not crash the translator."""
+        """LEGACY: An unrecognized finish_reason should not crash the CC translator."""
         response = simple_completion()
         response["choices"][0]["finish_reason"] = "some_future_reason"
 
@@ -376,7 +433,7 @@ class TestUnknownFinishReason:
         assert "stop_reason" in result
 
     def test_null_finish_reason(self) -> None:
-        """A null finish_reason (streaming intermediate) should be handled."""
+        """LEGACY: A null finish_reason (streaming intermediate) should be handled."""
         response = simple_completion()
         response["choices"][0]["finish_reason"] = None
 
@@ -385,7 +442,7 @@ class TestUnknownFinishReason:
         assert "stop_reason" in result
 
     def test_empty_string_finish_reason(self) -> None:
-        """An empty string finish_reason should be handled gracefully."""
+        """LEGACY: An empty string finish_reason should be handled gracefully."""
         response = simple_completion()
         response["choices"][0]["finish_reason"] = ""
 
@@ -394,10 +451,10 @@ class TestUnknownFinishReason:
 
 
 class TestEmptyChoicesArray:
-    """Handling of responses with no choices."""
+    """LEGACY: Handling of CC responses with no choices."""
 
     def test_empty_choices_handled(self) -> None:
-        """A response with an empty choices array should not crash."""
+        """LEGACY: A response with an empty choices array should not crash."""
         response = simple_completion()
         response["choices"] = []
 
@@ -406,7 +463,7 @@ class TestEmptyChoicesArray:
             openai_to_anthropic(response)
 
     def test_multiple_choices_uses_first(self) -> None:
-        """If multiple choices are present, the first is used."""
+        """LEGACY: If multiple choices are present, the first is used."""
         response = simple_completion()
         response["choices"].append(
             {
@@ -461,3 +518,141 @@ class TestContentBlockTypeVariants:
         except (ValueError, NotImplementedError, KeyError):
             # Acceptable: raising a clear error for unknown types
             pass
+
+
+# ---------------------------------------------------------------------------
+# PRIMARY: Responses API reverse edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesApiStopReasonEdgeCases:
+    """PRIMARY: Stop reason inference from Responses API output."""
+
+    def test_text_only_stop_reason(self) -> None:
+        """Text-only output infers stop_reason='end_turn'."""
+        response = responses_simple()
+        result = responses_to_anthropic(response)
+        assert result["stop_reason"] == "end_turn"
+
+    def test_function_call_stop_reason(self) -> None:
+        """Function call output infers stop_reason='tool_use'."""
+        response = responses_function_call()
+        result = responses_to_anthropic(response)
+        assert result["stop_reason"] == "tool_use"
+
+    def test_empty_output_stop_reason(self) -> None:
+        """Empty output array infers stop_reason='end_turn'."""
+        response = {"id": "resp_e", "output": [], "model": "grok-4-1-fast-reasoning", "usage": {}}
+        result = responses_to_anthropic(response)
+        assert result["stop_reason"] == "end_turn"
+
+    def test_unknown_output_type_does_not_crash(self) -> None:
+        """Unknown output item type is skipped without crashing."""
+        response = {
+            "id": "resp_future",
+            "output": [
+                {"type": "some_future_type", "data": "test"},
+                {"type": "message", "content": [{"type": "output_text", "text": "OK"}]},
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {},
+        }
+        result = responses_to_anthropic(response)
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "OK"
+
+
+class TestResponsesApiErrorEdgeCases:
+    """PRIMARY: Error response translation from Responses API."""
+
+    def test_rate_limit_error(self) -> None:
+        """429 error translates to Anthropic error format."""
+        from tests.translation.fixtures.responses_api import error_response_429
+        error = error_response_429()
+        result = translate_responses_response(error, status_code=429)
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "rate_limit_error"
+
+    def test_server_error(self) -> None:
+        """500 error translates to Anthropic error format."""
+        from tests.translation.fixtures.responses_api import error_response_500
+        error = error_response_500()
+        result = translate_responses_response(error, status_code=500)
+        assert result["type"] == "error"
+        assert "error" in result
+
+    def test_bad_request_error(self) -> None:
+        """400 error translates correctly."""
+        from tests.translation.fixtures.responses_api import error_response_400
+        error = error_response_400()
+        result = translate_responses_response(error, status_code=400)
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "invalid_request_error"
+
+    def test_error_includes_links(self) -> None:
+        """Translated errors include _links (Agentic API Standard Pattern 2)."""
+        from tests.translation.fixtures.responses_api import error_response_500
+        error = error_response_500()
+        result = translate_responses_response(error, status_code=500)
+        links = result.get("_links") or result.get("error", {}).get("_links")
+        assert links is not None
+
+    def test_error_includes_suggestion(self) -> None:
+        """Translated errors include suggestion (Agentic API Standard Pattern 3)."""
+        from tests.translation.fixtures.responses_api import error_response_429
+        error = error_response_429()
+        result = translate_responses_response(error, status_code=429)
+        suggestion = result["error"].get("suggestion") or result.get("suggestion", "")
+        assert len(suggestion) > 0
+
+
+class TestResponsesApiToolCallEdgeCases:
+    """PRIMARY: Tool call edge cases in Responses API format."""
+
+    def test_function_call_with_dict_arguments(self) -> None:
+        """Function call with dict (not string) arguments should work."""
+        response = {
+            "id": "resp_dict_args",
+            "output": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_dict",
+                    "name": "Bash",
+                    "arguments": {"command": "ls -la"},
+                },
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {},
+        }
+        result = responses_to_anthropic(response)
+        tool = result["content"][0]
+        assert tool["type"] == "tool_use"
+        assert tool["input"] == {"command": "ls -la"}
+
+    def test_multiple_function_calls(self) -> None:
+        """Multiple parallel function calls all translate correctly."""
+        from tests.translation.fixtures.responses_api import multi_function_call_response
+        response = multi_function_call_response()
+        result = responses_to_anthropic(response)
+        tool_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
+        assert len(tool_blocks) == 2
+        assert result["stop_reason"] == "tool_use"
+
+    def test_text_and_function_call_coexist(self) -> None:
+        """Text and function call in same response both translate."""
+        from tests.translation.fixtures.responses_api import multi_function_call_response
+        response = multi_function_call_response()
+        result = responses_to_anthropic(response)
+        text_blocks = [b for b in result["content"] if b["type"] == "text"]
+        tool_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
+        assert len(text_blocks) == 1
+        assert len(tool_blocks) == 2
+        assert "compare" in text_blocks[0]["text"].lower()
+
+    def test_reasoning_block_stripped(self) -> None:
+        """Reasoning blocks in output are stripped."""
+        from tests.translation.fixtures.responses_api import reasoning_response
+        response = reasoning_response()
+        result = responses_to_anthropic(response)
+        assert len(result["content"]) == 1
+        assert result["content"][0]["text"] == "The answer is 42."

--- a/tests/translation/test_forward.py
+++ b/tests/translation/test_forward.py
@@ -1,8 +1,14 @@
 """Tests for forward translation: Anthropic Messages API -> OpenAI Chat Completions API.
 
-These tests define the contract for the `translation.forward` module.
-Every test imports from a module that does not exist yet — that is
-intentional. The tests ARE the spec; Nexus implements against them.
+These tests define the contract for the `translation.forward` module,
+which handles the LEGACY Chat Completions forward path. The PRIMARY
+forward path (`translation.responses_forward`) is tested in
+`test_responses_forward.py`.
+
+Both paths share common logic (system prompt handling, content block
+translation, tool_use/tool_result conversion). The forward module tests
+remain relevant because the CC forward path is still available when
+XAI_USE_CHAT_COMPLETIONS=true.
 
 The forward translator is responsible for:
 1. Extracting the top-level system field into a system role message

--- a/tests/translation/test_newline_unescape.py
+++ b/tests/translation/test_newline_unescape.py
@@ -7,8 +7,8 @@ text with literal \\n instead of actual newline characters.
 
 Coverage:
 1. unescape_text() function directly
-2. Non-streaming reverse translation (_build_content)
-3. Streaming translation (adapter and stateless)
+2. Non-streaming reverse translation -- LEGACY (CC) and PRIMARY (Responses API)
+3. Streaming translation -- LEGACY (CC adapter) and PRIMARY (Responses adapter)
 4. Tool call arguments are NOT unescaped (structured data)
 5. E2E round trip through JSONResponse
 """
@@ -170,12 +170,12 @@ class TestUnescapeText:
 
 
 # ---------------------------------------------------------------------------
-# Non-streaming reverse translation
+# LEGACY: Non-streaming reverse translation (Chat Completions)
 # ---------------------------------------------------------------------------
 
 
 class TestNonStreamingNewlines:
-    """Multiline content through the non-streaming reverse translator."""
+    """LEGACY: Multiline content through the CC non-streaming reverse translator."""
 
     def test_literal_newlines_in_response_unescaped(self) -> None:
         """Literal \\n in Grok response text becomes real newlines."""
@@ -273,12 +273,84 @@ class TestNonStreamingNewlines:
 
 
 # ---------------------------------------------------------------------------
-# Streaming translation
+# PRIMARY: Non-streaming reverse translation (Responses API)
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesApiNonStreamingNewlines:
+    """PRIMARY: Multiline content through the Responses API reverse translator."""
+
+    def test_literal_newlines_in_response_unescaped(self) -> None:
+        """Literal \\n in Responses API output text becomes real newlines."""
+        from translation.responses_reverse import responses_to_anthropic
+        response = {
+            "id": "resp_nl",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "Step 1\\nStep 2\\nStep 3"}]},
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {},
+        }
+        result = responses_to_anthropic(response)
+        text = result["content"][0]["text"]
+        assert text == "Step 1\nStep 2\nStep 3"
+        assert text.count("\n") == 2
+
+    def test_real_newlines_preserved(self) -> None:
+        """Real newlines in Responses API output pass through correctly."""
+        from translation.responses_reverse import responses_to_anthropic
+        response = {
+            "id": "resp_nl2",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "Step 1\nStep 2\nStep 3"}]},
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {},
+        }
+        result = responses_to_anthropic(response)
+        text = result["content"][0]["text"]
+        assert text == "Step 1\nStep 2\nStep 3"
+
+    def test_multiline_plan_e2e(self) -> None:
+        """Full plan with multiple paragraphs through Responses API."""
+        from translation.responses_reverse import responses_to_anthropic
+        plan = (
+            "## Implementation Plan\\n"
+            "\\n"
+            "### Phase 1: Research\\n"
+            "- Read existing code\\n"
+            "- Identify dependencies\\n"
+            "\\n"
+            "### Phase 2: Implementation\\n"
+            "- Create new module\\n"
+            "- Write tests\\n"
+            "\\n"
+            "### Phase 3: Review\\n"
+            "- Run test suite\\n"
+            "- Create PR"
+        )
+        response = {
+            "id": "resp_plan",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": plan}]},
+            ],
+            "model": "grok-4-1-fast-reasoning",
+            "usage": {},
+        }
+        result = responses_to_anthropic(response)
+        text = result["content"][0]["text"]
+        assert "## Implementation Plan\n" in text
+        assert "### Phase 1: Research\n" in text
+        assert text.count("\n") == 12
+
+
+# ---------------------------------------------------------------------------
+# LEGACY: Streaming translation (Chat Completions)
 # ---------------------------------------------------------------------------
 
 
 class TestStreamingNewlines:
-    """Multiline content through the streaming translator."""
+    """LEGACY: Multiline content through the CC streaming translator."""
 
     def test_stateless_literal_newline_unescaped(self) -> None:
         """translate_sse_event unescapes literal \\n in text deltas."""

--- a/tests/translation/test_reverse.py
+++ b/tests/translation/test_reverse.py
@@ -1,10 +1,12 @@
-"""Tests for reverse translation: OpenAI Chat Completions API -> Anthropic Messages API.
+"""LEGACY: Tests for reverse translation: OpenAI Chat Completions API -> Anthropic Messages API.
 
-These tests define the contract for the `translation.reverse` module.
-The reverse translator converts xAI/Grok responses back into the format
-that Claude Code expects (Anthropic Messages API).
+These tests define the contract for the `translation.reverse` module,
+which handles the LEGACY Chat Completions format (XAI_USE_CHAT_COMPLETIONS=true).
 
-Key responsibilities:
+The PRIMARY reverse translation path is `translation.responses_reverse`,
+tested in `test_responses_reverse.py`.
+
+Key responsibilities of the legacy path:
 1. String content -> content block arrays
 2. tool_calls -> tool_use content blocks
 3. finish_reason mapping (stop->end_turn, tool_calls->tool_use, length->max_tokens)

--- a/tests/translation/test_round_trip.py
+++ b/tests/translation/test_round_trip.py
@@ -1,9 +1,13 @@
-"""Tests for round-trip translation fidelity.
+"""LEGACY: Tests for round-trip translation fidelity via Chat Completions path.
 
-These tests verify that translating forward (Anthropic -> OpenAI) and then
-reverse (OpenAI -> Anthropic) preserves critical information. Perfect
+These tests verify that translating forward (Anthropic -> OpenAI CC) and then
+reverse (OpenAI CC -> Anthropic) preserves critical information. Perfect
 round-trip fidelity is not expected (some fields are format-specific),
 but tool IDs, content, and structural relationships must survive.
+
+This tests the LEGACY Chat Completions round trip. For the PRIMARY
+Responses API round trip, see test_responses_forward.py and
+test_responses_reverse.py.
 """
 
 import json

--- a/tests/translation/test_streaming.py
+++ b/tests/translation/test_streaming.py
@@ -1,8 +1,11 @@
-"""Tests for streaming translation: OpenAI SSE chunks <-> Anthropic SSE events.
+"""LEGACY: Tests for streaming translation: OpenAI SSE chunks <-> Anthropic SSE events.
 
-These tests define the contract for the `translation.streaming` module.
-The streaming translator must convert OpenAI's delta-based streaming format
-into Anthropic's typed event stream (message_start, content_block_delta, etc.).
+These tests define the contract for the `translation.streaming` module,
+which handles the LEGACY Chat Completions streaming format
+(XAI_USE_CHAT_COMPLETIONS=true).
+
+The PRIMARY streaming path is `translation.responses_streaming`,
+tested in `test_responses_streaming.py`.
 
 This is the hardest part of the translation layer because:
 1. State must be maintained across chunks (partial tool call arguments)

--- a/tests/translation/test_streaming_usage.py
+++ b/tests/translation/test_streaming_usage.py
@@ -1,7 +1,11 @@
-"""Tests for streaming adapter usage tracking (Issue #26).
+"""LEGACY: Tests for Chat Completions streaming adapter usage tracking (Issue #26).
 
 Verifies that OpenAIToAnthropicStreamAdapter captures token usage
-from streaming chunks for post-stream token logging.
+from Chat Completions streaming chunks for post-stream token logging.
+
+This tests the LEGACY Chat Completions streaming adapter. The PRIMARY
+streaming path (ResponsesStreamAdapter) has usage capture tested in
+test_responses_streaming.py::test_usage_captured.
 """
 
 from __future__ import annotations

--- a/translation/tools.py
+++ b/translation/tools.py
@@ -63,7 +63,7 @@ def reset_enrichment_overhead() -> None:
 
     Call at the start of each request to prevent stale values from
     a previous request leaking into the current one when no tools
-    are present (translate_tools is not called for tool-free requests).
+    are present (enrich_tools is not called for tool-free requests).
     """
     global _last_enrichment_overhead
     _last_enrichment_overhead = 0


### PR DESCRIPTION
## Summary

- Created `tests/translation/fixtures/responses_api.py` with Responses API fixtures (primary path)
- Marked 6 legacy test files/fixtures with clear LEGACY labels in docstrings and section headers
- Added 21 new Responses API tests covering edge cases, error translation, newline unescaping, tool calls, and parametrized fixtures
- Updated smoke test and token integration mocks from Chat Completions to Responses API format
- Fixed `reset_enrichment_overhead()` docstring (Kelvin's nit from PR #57: `translate_tools` -> `enrich_tools`)
- Test count: **660 -> 681** (21 added, 0 removed, 0 broken)

## What Changed

**LEGACY-marked files** (Chat Completions tests retained for `XAI_USE_CHAT_COMPLETIONS=true`):
- `test_reverse.py` -- CC reverse translation
- `test_streaming.py` -- CC streaming adapter
- `test_streaming_usage.py` -- CC streaming usage capture
- `test_round_trip.py` -- CC round-trip fidelity
- `fixtures/openai_completions.py` -- CC response fixtures
- `fixtures/streaming_events.py` -- CC SSE chunks (section marker)

**PRIMARY path additions** (Responses API):
- `fixtures/responses_api.py` -- new fixture file with text, function_call, multi-function, reasoning, empty, and error fixtures
- Edge case tests: stop reason inference, error translation with _links/suggestions, tool call variants, newline unescaping, missing fields
- Parametrized fixtures in conftest for Responses API response and error variants

**Mock format updates** (CC -> Responses API):
- `tests/smoke.py` -- `MOCK_XAI_RESPONSE` and thinking-strip mock
- `tests/bridge/test_token_integration.py` -- `_SIMPLE_RESPONSE` and `_TOOL_CALL_RESPONSE`

Closes #54

## Test plan

- [x] All 681 tests pass (`python3 -m pytest -x -q` -- 681 passed in ~48s)
- [x] Test count >= 660 baseline (681 > 660)
- [x] No Chat Completions mocks in primary path test files
- [x] Legacy tests clearly marked and still passing
- [x] Smoke test uses Responses API mock format
- [x] Token integration uses Responses API mock format
- [x] Docstring nit from PR #57 fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)