### PR TITLE
fix: Remove reasoning.effort for grok-4.20-reasoning-latest

### DIFF
--- a/translation/responses_forward.py
+++ b/translation/responses_forward.py
@@ -71,8 +71,8 @@ def anthropic_to_responses(request: dict[str, Any]) -> dict[str, Any]:
         "stream": bool(request.get("stream")),
     }
 
-    # Reasoning effort for models that support it (grok-4.20-*, grok-4).
-    if "4.20" in resolved_model or resolved_model == "grok-4":
+    # Reasoning effort only for grok-4.20-multi-agent (only model that supports it).
+    if "multi-agent" in resolved_model:
         result["reasoning"] = {"effort": "high"}
 
     # Translate tools to Responses API format (enrichment runs inside).


### PR DESCRIPTION
## Summary
- grok-4.20-reasoning-latest rejects `reasoningEffort` parameter (400 error)
- Only grok-4.20-multi-agent supports it per xAI docs
- Restrict reasoning.effort to multi-agent model only

Hotfix — Kelvin hit this live after pulling #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)