### PR TITLE
fix: Remove conciseness prompt injection from bridge preamble

### DIFF
--- a/enrichment/system_preamble.py
+++ b/enrichment/system_preamble.py
@@ -132,10 +132,11 @@ without explicit user request
 
 - Use tool results as the source of truth — never fabricate file contents \
 or command output
-- Keep responses concise and focused on the task
 - Include file paths with line numbers when referencing code
 - Do not add comments, docstrings, or type annotations to code you did not change
 - Do not add emojis unless the user explicitly requests them
+- Let the user's CLAUDE.md, rules, and skills determine your tone, \
+verbosity, and communication style — do not impose your own defaults
 
 ## 7. Orchestration Tools — Planning vs Execution
 


### PR DESCRIPTION
## Summary
- Removed "Keep responses concise and focused on the task" from the bridge preamble
- Added directive to let user's CLAUDE.md, rules, and skills determine tone/verbosity
- The bridge should teach Grok tool conventions, not override the user's communication preferences

The preamble was prompt-injecting a conciseness directive that competed with the user's own rules. Grok followed it more rigidly than Claude (which has RL calibration), producing robotic/terse responses.

## Test plan
- [x] 713/713 tests pass
- [ ] Kelvin verifies more natural response style after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)