### PR TITLE
feat: Enable xAI prompt caching via x-grok-conv-id header

### DIFF
--- a/bridge/token_logger.py
+++ b/bridge/token_logger.py
@@ -47,6 +47,7 @@ def log_token_usage(
     *,
     input_tokens: int,
     output_tokens: int,
+    cached_tokens: int = 0,
     enrichment_overhead_tokens: int = 0,
     elapsed_seconds: float = 0.0,
     is_streaming: bool = False,
@@ -60,6 +61,7 @@ def log_token_usage(
     Args:
         input_tokens: Tokens consumed by the prompt (from xAI usage).
         output_tokens: Tokens generated in the response (from xAI usage).
+        cached_tokens: Tokens served from xAI prompt cache (90% discount).
         enrichment_overhead_tokens: Estimated tokens added by enrichment.
         elapsed_seconds: Total request time in seconds.
         is_streaming: Whether this was a streaming request.
@@ -68,20 +70,24 @@ def log_token_usage(
     total_tokens = input_tokens + output_tokens
     mode = "stream" if is_streaming else "sync"
 
-    summary = {
+    summary: dict[str, Any] = {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": total_tokens,
         "enrichment_overhead_tokens": enrichment_overhead_tokens,
     }
+    if cached_tokens:
+        summary["cached_tokens"] = cached_tokens
 
+    cache_part = f" cached={cached_tokens}" if cached_tokens else ""
     logger.info(
-        "Token usage: model=%s input=%d output=%d total=%d "
+        "Token usage: model=%s input=%d output=%d total=%d%s "
         "enrichment_overhead=%d mode=%s elapsed=%.2fs",
         model or "unknown",
         input_tokens,
         output_tokens,
         total_tokens,
+        cache_part,
         enrichment_overhead_tokens,
         mode,
         elapsed_seconds,

--- a/handlers/responses.py
+++ b/handlers/responses.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from typing import Any
 
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -21,6 +22,12 @@ from translation.responses_streaming import ResponsesStreamAdapter
 from translation.tools import get_last_enrichment_overhead
 
 logger = get_logger("main")
+
+# Stable conversation ID for xAI prompt caching server affinity.
+# Generated once per bridge process — all requests route to the same xAI
+# server, enabling automatic prefix caching (90% input token discount).
+# See: https://docs.x.ai/developers/advanced-api-usage/prompt-caching
+_CONV_ID = str(uuid.uuid4())
 
 
 async def handle_responses(
@@ -36,7 +43,11 @@ async def handle_responses(
     logger.debug("Translated Responses request: %s", json.dumps(sanitize_request(responses_body), default=str))
     dump_json("request_responses", sanitize_request(responses_body))
 
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "x-grok-conv-id": _CONV_ID,
+    }
 
     if responses_body.get("stream"):
         return await stream_responses(
@@ -56,6 +67,7 @@ async def handle_responses(
                                         "suggestion": "Unexpected response format from xAI."}})
 
     usage = data.get("usage", {})
+    prompt_details = usage.get("prompt_tokens_details", {})
     output = data.get("output", [])
     output_types = [item.get("type", "?") for item in output] if isinstance(output, list) else []
     logger.info(
@@ -66,6 +78,7 @@ async def handle_responses(
     log_token_usage(
         input_tokens=usage.get("input_tokens", usage.get("prompt_tokens", 0)),
         output_tokens=usage.get("output_tokens", usage.get("completion_tokens", 0)),
+        cached_tokens=prompt_details.get("cached_tokens", 0),
         enrichment_overhead_tokens=get_last_enrichment_overhead(),
         elapsed_seconds=elapsed, is_streaming=False, model=responses_body.get("model", ""),
     )
@@ -126,9 +139,11 @@ async def stream_responses(
             logger.info("Responses streaming complete events=%d elapsed=%.2fs", event_count, elapsed)
 
             usage = adapter.usage
+            stream_prompt_details = usage.get("prompt_tokens_details", {})
             log_token_usage(
                 input_tokens=usage.get("input_tokens", usage.get("prompt_tokens", 0)),
                 output_tokens=usage.get("output_tokens", usage.get("completion_tokens", 0)),
+                cached_tokens=stream_prompt_details.get("cached_tokens", 0),
                 enrichment_overhead_tokens=enrichment_overhead,
                 elapsed_seconds=elapsed, is_streaming=True, model=model,
             )

--- a/main.py
+++ b/main.py
@@ -52,6 +52,13 @@ else:
     logger.info("API path: Responses API (default, issue #51 migration)")
 
 
+@app.head("/")
+@app.get("/")
+async def root() -> dict:
+    """Health check for Claude Code connectivity probes (HEAD /)."""
+    return {"status": "ok"}
+
+
 @app.get("/manifest")
 async def get_manifest() -> dict:
     with open("manifest.json") as f:
@@ -62,7 +69,7 @@ async def get_manifest() -> dict:
 async def health() -> dict:
     return {
         "status": "healthy",
-        "model": os.getenv("GROK_MODEL", "grok-4-1-fast-reasoning"),
+        "model": os.getenv("GROK_MODEL", "grok-4.20-reasoning-latest"),
         "enrichment_mode": enricher.config.mode,
     }
 

--- a/translation/responses_reverse.py
+++ b/translation/responses_reverse.py
@@ -38,18 +38,26 @@ def responses_to_anthropic(response: dict[str, Any]) -> dict[str, Any]:
     stop_reason = _infer_stop_reason(output)
 
     usage = response.get("usage", {})
+    prompt_details = usage.get("prompt_tokens_details", {})
+    cached_tokens = prompt_details.get("cached_tokens", 0)
+
+    anthropic_usage: dict[str, Any] = {
+        "input_tokens": usage.get("input_tokens", usage.get("prompt_tokens", 0)),
+        "output_tokens": usage.get("output_tokens", usage.get("completion_tokens", 0)),
+    }
+    if cached_tokens:
+        anthropic_usage["cache_read_input_tokens"] = cached_tokens
+        anthropic_usage["cache_creation_input_tokens"] = 0
+
     return {
         "id": rid,
         "type": "message",
         "role": "assistant",
         "content": content,
-        "model": response.get("model", "grok-4-1-fast-reasoning"),
+        "model": response.get("model", "grok-4.20-reasoning-latest"),
         "stop_reason": stop_reason,
         "stop_sequence": None,
-        "usage": {
-            "input_tokens": usage.get("input_tokens", usage.get("prompt_tokens", 0)),
-            "output_tokens": usage.get("output_tokens", usage.get("completion_tokens", 0)),
-        },
+        "usage": anthropic_usage,
     }
 
 

--- a/translation/responses_streaming.py
+++ b/translation/responses_streaming.py
@@ -68,9 +68,9 @@ class ResponsesStreamAdapter:
         self._text_block_open = False
         self._tool_block_open = False
         self._block_index = 0
-        self._model = "grok-4-1-fast-reasoning"
+        self._model = "grok-4.20-reasoning-latest"
         self._q: list[dict[str, Any]] = []
-        self.usage: dict[str, int] = {}
+        self.usage: dict[str, Any] = {}
 
     def __aiter__(self) -> ResponsesStreamAdapter:
         return self


### PR DESCRIPTION
## Summary
- Add `x-grok-conv-id` header to all Responses API requests for server affinity
- xAI's automatic prompt caching gives **90% discount** on cached input tokens but requires same-server routing
- Surface `cached_tokens` from xAI response in Anthropic usage format (`cache_read_input_tokens`)
- Add `cached_tokens` field to token logger for cache hit monitoring
- Add root route for `HEAD /` health probes (subsumes #68)
- Fix stale model names in `responses_streaming.py` and `main.py`

## How it works
A stable UUID is generated once per bridge process and sent as `x-grok-conv-id` on every request. This routes all requests to the same xAI server, where the automatic prefix cache activates. The system prompt, tool definitions, and conversation history prefix get cached after the first request.

## Cost impact
For a 30-turn session: ~$1.62 → ~$0.32 in input tokens (~80% savings).

## Observability
Logs now show `cached=N` when cache hits occur:
```
Token usage: model=grok-4.20-reasoning-latest input=58238 output=515 total=58753 cached=45000 ...
```

Closes #69. Subsumes #68.

## Test plan
- [x] 713/713 tests pass
- [ ] Verify cache hits in logs after deployment (look for `cached=` in token logger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)