### PR TITLE
debug: Log raw xAI streaming usage for cache diagnostics

### DIFF
--- a/handlers/responses.py
+++ b/handlers/responses.py
@@ -139,6 +139,7 @@ async def stream_responses(
             logger.info("Responses streaming complete events=%d elapsed=%.2fs", event_count, elapsed)
 
             usage = adapter.usage
+            logger.info("xAI raw streaming usage: %s", json.dumps(usage, default=str))
             stream_prompt_details = usage.get("prompt_tokens_details", {})
             log_token_usage(
                 input_tokens=usage.get("input_tokens", usage.get("prompt_tokens", 0)),


### PR DESCRIPTION
One-line debug log to dump the raw usage object from xAI streaming responses. Need to see if prompt_tokens_details.cached_tokens is present. Remove after diagnosis.