### PR TITLE
fix: Correct xAI cache field name (input_tokens_details)

### DIFF
--- a/handlers/responses.py
+++ b/handlers/responses.py
@@ -67,7 +67,7 @@ async def handle_responses(
                                         "suggestion": "Unexpected response format from xAI."}})
 
     usage = data.get("usage", {})
-    prompt_details = usage.get("prompt_tokens_details", {})
+    prompt_details = usage.get("input_tokens_details", {})
     output = data.get("output", [])
     output_types = [item.get("type", "?") for item in output] if isinstance(output, list) else []
     logger.info(
@@ -140,7 +140,7 @@ async def stream_responses(
 
             usage = adapter.usage
             logger.info("xAI raw streaming usage: %s", json.dumps(usage, default=str))
-            stream_prompt_details = usage.get("prompt_tokens_details", {})
+            stream_prompt_details = usage.get("input_tokens_details", {})
             log_token_usage(
                 input_tokens=usage.get("input_tokens", usage.get("prompt_tokens", 0)),
                 output_tokens=usage.get("output_tokens", usage.get("completion_tokens", 0)),

--- a/translation/responses_reverse.py
+++ b/translation/responses_reverse.py
@@ -38,7 +38,7 @@ def responses_to_anthropic(response: dict[str, Any]) -> dict[str, Any]:
     stop_reason = _infer_stop_reason(output)
 
     usage = response.get("usage", {})
-    prompt_details = usage.get("prompt_tokens_details", {})
+    prompt_details = usage.get("input_tokens_details", {})
     cached_tokens = prompt_details.get("cached_tokens", 0)
 
     anthropic_usage: dict[str, Any] = {


### PR DESCRIPTION
xAI returns `cached_tokens` under `input_tokens_details`, not `prompt_tokens_details`. Debug log from #72 confirmed:

```json
{"input_tokens": 84054, "input_tokens_details": {"cached_tokens": 1216}, ...}
```

Three locations fixed. Cache metrics will now surface correctly in logs and Anthropic usage response.

Note: cache hit rate is low (~1.4%) because xAI prefix caching only matches the exact start of the request. The system prompt (~1216 tokens) caches, but tool definitions and conversation history change each turn, breaking the prefix match early. This is expected behavior per xAI docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)