### PR TITLE
debug: Cache prefix hashing for stability diagnosis

### DIFF
--- a/handlers/responses.py
+++ b/handlers/responses.py
@@ -6,6 +6,7 @@ The Responses API is the primary translation path.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 import uuid
@@ -39,6 +40,23 @@ async def handle_responses(
 ) -> JSONResponse | StreamingResponse:
     """Forward request via /v1/responses (multi-agent models)."""
     responses_body = anthropic_to_responses(body)
+
+    # Cache diagnostics: hash system prompt, tools, and full prefix to track stability.
+    input_msgs = responses_body.get("input", [])
+    system_content = ""
+    for msg in input_msgs:
+        if msg.get("role") == "system":
+            system_content = msg.get("content", "")
+            break
+    tools_json = json.dumps(responses_body.get("tools", []), sort_keys=True, default=str)
+    sys_hash = hashlib.md5(system_content.encode()).hexdigest()[:8]
+    tools_hash = hashlib.md5(tools_json.encode()).hexdigest()[:8]
+    sys_tokens = len(system_content) // 4  # rough estimate
+    tools_tokens = len(tools_json) // 4
+    logger.info(
+        "Cache prefix: sys_hash=%s sys_tokens~%d tools_hash=%s tools_tokens~%d msgs=%d",
+        sys_hash, sys_tokens, tools_hash, tools_tokens, len(input_msgs) - 1,
+    )
 
     logger.debug("Translated Responses request: %s", json.dumps(sanitize_request(responses_body), default=str))
     dump_json("request_responses", sanitize_request(responses_body))


### PR DESCRIPTION
## What
Logs MD5 hashes of system prompt and tool definitions per request:
```
Cache prefix: sys_hash=a1b2c3d4 sys_tokens~20000 tools_hash=e5f6g7h8 tools_tokens~2000 msgs=5
```

## Why
Only 1,216/84,054 tokens caching. Need to determine if the system prompt and tools are byte-identical across requests. If the hashes are stable, the cache should extend further — something else is breaking it. If they change, we know which component is the culprit.

Diagnostic — remove after analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)